### PR TITLE
Fix TypeScript errors in chat components and Google auth

### DIFF
--- a/chartsmith-app/app/auth/google/page.tsx
+++ b/chartsmith-app/app/auth/google/page.tsx
@@ -7,6 +7,7 @@ import { useToast } from "@/components/toast/use-toast";
 import { Card } from "@/components/ui/Card";
 import { exchangeGoogleCodeForSession } from "@/lib/auth/actions/exchange-google-code";
 import { createWorkspaceAction } from "@/lib/workspace/actions/create-workspace-from-prompt";
+import { findSession } from "@/lib/auth/session";
 
 function GoogleCallback() {
   const searchParams = useSearchParams();
@@ -36,8 +37,12 @@ function GoogleCallback() {
           if (pendingPrompt) {
             try {
               localStorage.removeItem('pendingPrompt'); // Clear the stored prompt
-              // Create workspace with the stored prompt
-              const workspaceId = await createWorkspaceAction({ jwt }, "prompt", pendingPrompt);
+              // Get session from JWT and create workspace with the stored prompt
+              const session = await findSession(jwt);
+              if (!session) {
+                throw new Error("Failed to get session");
+              }
+              const workspaceId = await createWorkspaceAction(session, "prompt", pendingPrompt);
               window.location.href = `/workspace/${workspaceId}`;
             } catch (error) {
               console.error("Failed to create workspace:", error);

--- a/chartsmith-app/components/editor/chat/ChatMessage.tsx
+++ b/chartsmith-app/components/editor/chat/ChatMessage.tsx
@@ -4,12 +4,11 @@ import { Session } from "@/lib/types/session";
 import { useTheme } from "../../../contexts/ThemeContext";
 import { Button } from "@/components/ui/Button";
 import { FeedbackModal } from "@/components/FeedbackModal";
-import { Tooltip } from "@/components/ui/Tooltip";
 import { ignorePlanAction } from "@/lib/workspace/actions/ignore-plan";
-import { getWorkspaceMessagesAction } from "@/lib/workspace/actions/get-workspace-messages";
 
 interface ChatMessageProps {
   message: Message;
+  messages: Message[];
   onApplyChanges?: () => void;
   session: Session;
   workspaceId: string;
@@ -17,7 +16,7 @@ interface ChatMessageProps {
   setMessages: (messages: Message[]) => void;
 }
 
-export function ChatMessage({ message, onApplyChanges, session, workspaceId, showActions = true, setMessages }: ChatMessageProps) {
+export function ChatMessage({ message, messages, onApplyChanges, session, workspaceId, showActions = true, setMessages }: ChatMessageProps) {
   const { theme } = useTheme();
   const [showReportModal, setShowReportModal] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);
@@ -91,14 +90,13 @@ export function ChatMessage({ message, onApplyChanges, session, workspaceId, sho
                             onClick={async () => {
                               setShowDropdown(false);
                               // Optimistically update local state
-                              setMessages(prevMessages => {
-                                return prevMessages.map(m => {
-                                  if (m.id === message.id) {
-                                    return { ...m, isIgnored: true };
-                                  }
-                                  return m;
-                                });
+                              const updatedMessages = messages.map(m => {
+                                if (m.id === message.id) {
+                                  return { ...m, isIgnored: true };
+                                }
+                                return m;
                               });
+                              setMessages(updatedMessages);
                               // Make server call in background
                               await ignorePlanAction(session, workspaceId, message.id);
                             }}

--- a/chartsmith-app/components/editor/chat/ChatPanel.tsx
+++ b/chartsmith-app/components/editor/chat/ChatPanel.tsx
@@ -33,6 +33,7 @@ export function ChatPanel({ messages, onSendMessage, onApplyChanges, session, wo
           <ChatMessage
             key={message.id || index}
             message={message}
+            messages={messages}
             onApplyChanges={() => onApplyChanges?.(message)}
             session={session}
             workspaceId={workspaceId}

--- a/chartsmith-app/components/editor/workspace/WorkspaceContent.tsx
+++ b/chartsmith-app/components/editor/workspace/WorkspaceContent.tsx
@@ -299,6 +299,7 @@ export function WorkspaceContent({ initialWorkspace, workspaceId }: WorkspaceCon
                   <ChatMessage
                     key={message.id || index}
                     message={message}
+                    messages={messages}
                     session={session}
                     workspaceId={workspaceId}
                     showActions={index === messages.length - 1}


### PR DESCRIPTION
This PR fixes TypeScript errors in the chat components and Google authentication:

- Fixed Google auth callback to properly convert JWT to a Session object
- Added missing `messages` prop to ChatMessage component
- Updated all components using ChatMessage to pass the required messages prop
- Fixed type errors in chat message state updates

These changes resolve all TypeScript errors and allow the project to build successfully.