### PR TITLE
Fix build errors and TypeScript types

### DIFF
--- a/chartsmith-app/components/editor/chat/ChatMessage.tsx
+++ b/chartsmith-app/components/editor/chat/ChatMessage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useRef, useEffect } from "react";
 import { Message } from "../types";
 import { Session } from "@/lib/types/session";
+import { Workspace } from "@/lib/types/workspace";
 import { useTheme } from "../../../contexts/ThemeContext";
 import { Button } from "@/components/ui/Button";
 import { FeedbackModal } from "@/components/FeedbackModal";
@@ -14,9 +15,10 @@ interface ChatMessageProps {
   showActions?: boolean;
   /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
   setMessages?: (messages: Message[]) => void;
+  setWorkspace?: React.Dispatch<React.SetStateAction<Workspace>>;
 }
 
-export function ChatMessage({ message, onApplyChanges, session, workspaceId, showActions = true, setMessages }: ChatMessageProps) {
+export function ChatMessage({ message, onApplyChanges, session, workspaceId, showActions = true, setMessages, setWorkspace }: ChatMessageProps) {
   const { theme } = useTheme();
   const [showReportModal, setShowReportModal] = useState(false);
   const [showDropdown, setShowDropdown] = useState(false);

--- a/chartsmith-app/components/editor/chat/PlanChatMessage.tsx
+++ b/chartsmith-app/components/editor/chat/PlanChatMessage.tsx
@@ -8,7 +8,7 @@ import { ignorePlanAction } from "@/lib/workspace/actions/ignore-plan";
 import { ThumbsUp, ThumbsDown, Send, ChevronDown, ChevronUp } from "lucide-react";
 import ReactMarkdown from "react-markdown";
 import { createPlanAction } from "@/lib/workspace/actions/create-plan";
-import { Plan } from "@/lib/types/workspace";
+import { Plan, Workspace } from "@/lib/types/workspace";
 
 interface PlanChatMessageProps {
   showActions?: boolean;

--- a/chartsmith-app/components/editor/types.ts
+++ b/chartsmith-app/components/editor/types.ts
@@ -26,6 +26,12 @@ export interface Message {
   isApplied?: boolean;
   isApplying?: boolean;
   isIgnored?: boolean;
+  role?: string;
+  createdAt?: Date;
+  workspaceId?: string;
+  planId?: string;
+  userId?: string;
+  isOptimistic?: boolean;
 }
 
 // Interface for raw message from server before normalization

--- a/chartsmith-app/components/editor/workspace/WorkspaceContent.tsx
+++ b/chartsmith-app/components/editor/workspace/WorkspaceContent.tsx
@@ -237,7 +237,7 @@ export function WorkspaceContent({ initialWorkspace, workspaceId }: WorkspaceCon
         centrifugeRef.current = null;
       }
     };
-  }, [centrifugoToken, session?.user.id, workspace?.id]); // Only core connection dependencies
+  }, [centrifugoToken, session?.user.id, workspace?.id, handlePlanUpdated, session]); // Include all dependencies
 
   // Track previous workspace state for follow mode
   const prevWorkspaceRef = React.useRef<Workspace | null>(null);


### PR DESCRIPTION
This PR fixes several build errors and TypeScript type issues:

- Added missing properties to Message interface (role, createdAt, workspaceId, planId, userId, isOptimistic)
- Added setWorkspace prop to ChatMessage component
- Fixed React Hook dependencies in WorkspaceContent.tsx

The build now completes successfully with no TypeScript errors or warnings.