### PR TITLE
fix: wrap error returns with fmt.Errorf and %w

### DIFF
--- a/cmd/bootstrap.go
+++ b/cmd/bootstrap.go
@@ -1,318 +1,318 @@
 package cmd
 
 import (
-	"context"
-	"crypto/sha256"
-	"database/sql"
-	"encoding/hex"
-	"fmt"
-	"hash/fnv"
-	"io"
-	"os"
-	"path/filepath"
-	"sort"
-	"strings"
+        "context"
+        "crypto/sha256"
+        "database/sql"
+        "encoding/hex"
+        "fmt"
+        "hash/fnv"
+        "io"
+        "os"
+        "path/filepath"
+        "sort"
+        "strings"
 
-	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/session"
-	"github.com/jackc/pgx/v5"
-	"github.com/replicatedhq/chartsmith/pkg/embedding"
-	"github.com/replicatedhq/chartsmith/pkg/llm"
-	"github.com/replicatedhq/chartsmith/pkg/param"
-	"github.com/replicatedhq/chartsmith/pkg/persistence"
-	"github.com/spf13/cobra"
-	"github.com/spf13/viper"
-	yaml "gopkg.in/yaml.v2"
+        "github.com/aws/aws-sdk-go/aws"
+        "github.com/aws/aws-sdk-go/aws/session"
+        "github.com/jackc/pgx/v5"
+        "github.com/replicatedhq/chartsmith/pkg/embedding"
+        "github.com/replicatedhq/chartsmith/pkg/llm"
+        "github.com/replicatedhq/chartsmith/pkg/param"
+        "github.com/replicatedhq/chartsmith/pkg/persistence"
+        "github.com/spf13/cobra"
+        "github.com/spf13/viper"
+        yaml "gopkg.in/yaml.v2"
 )
 
 func BootstrapCmd() *cobra.Command {
-	bootstrapCmd := &cobra.Command{
-		Use:   "bootstrap",
-		Short: "Bootstrap the initial workspace data",
-		PreRunE: func(cmd *cobra.Command, args []string) error {
-			v := viper.GetViper()
-			if err := v.BindPFlags(cmd.Flags()); err != nil {
-				return fmt.Errorf("failed to bind flags: %w", err)
-			}
+        bootstrapCmd := &cobra.Command{
+                Use:   "bootstrap",
+                Short: "Bootstrap the initial workspace data",
+                PreRunE: func(cmd *cobra.Command, args []string) error {
+                        v := viper.GetViper()
+                        if err := v.BindPFlags(cmd.Flags()); err != nil {
+                                return fmt.Errorf("failed to bind flags: %w", err)
+                        }
 
-			sess, err := session.NewSession(aws.NewConfig().WithCredentialsChainVerboseErrors(true))
-			if err != nil {
-				// previous use of session.New did not fail on error
-				// we have not yet initialized logging, so we cannot use saaskit/log
-				fmt.Printf("Failed to create aws session: %v\n", err)
-			}
+                        sess, err := session.NewSession(aws.NewConfig().WithCredentialsChainVerboseErrors(true))
+                        if err != nil {
+                                // previous use of session.New did not fail on error
+                                // we have not yet initialized logging, so we cannot use saaskit/log
+                                fmt.Printf("Failed to create aws session: %v\n", err)
+                        }
 
-			if err := param.Init(sess); err != nil {
-				return fmt.Errorf("failed to init params: %w", err)
-			}
+                        if err := param.Init(sess); err != nil {
+                                return fmt.Errorf("failed to init params: %w", err)
+                        }
 
-			return nil
-		},
-		RunE: func(cmd *cobra.Command, args []string) error {
-			v := viper.GetViper()
+                        return nil
+                },
+                RunE: func(cmd *cobra.Command, args []string) error {
+                        v := viper.GetViper()
 
-			if err := runBootstrap(cmd.Context(), param.Get().PGURI, v.GetString("workspace-dir"), v.GetBool("force")); err != nil {
-				return fmt.Errorf("failed to bootstrap workspace: %w", err)
-			}
+                        if err := runBootstrap(cmd.Context(), param.Get().PGURI, v.GetString("workspace-dir"), v.GetBool("force")); err != nil {
+                                return fmt.Errorf("failed to bootstrap workspace: %w", err)
+                        }
 
-			return nil
-		},
-	}
+                        return nil
+                },
+        }
 
-	wd, err := os.Getwd()
-	if err != nil {
-		return nil
-	}
+        wd, err := os.Getwd()
+        if err != nil {
+                return nil
+        }
 
-	bootstrapCmd.Flags().String("workspace-dir", filepath.Join(wd, "bootstrap", "default-workspace"), "Workspace directory")
-	bootstrapCmd.Flags().Bool("force", false, "Force bootstrap even if the directory is already bootstrapped")
+        bootstrapCmd.Flags().String("workspace-dir", filepath.Join(wd, "bootstrap", "default-workspace"), "Workspace directory")
+        bootstrapCmd.Flags().Bool("force", false, "Force bootstrap even if the directory is already bootstrapped")
 
-	return bootstrapCmd
+        return bootstrapCmd
 }
 
 func runBootstrap(ctx context.Context, pgURI string, workspaceDir string, force bool) error {
-	// let's generate an ID for this bootstrap workspace, how about using a hash of the workspace dir string?
-	workspaceID := hashString(workspaceDir)
-	workspaceName := filepath.Base(workspaceDir)
+        // let's generate an ID for this bootstrap workspace, how about using a hash of the workspace dir string?
+        workspaceID := hashString(workspaceDir)
+        workspaceName := filepath.Base(workspaceDir)
 
-	currentDirectoryHash, err := directoryHashDeterministic(workspaceDir)
-	if err != nil {
-		return fmt.Errorf("failed to hash workspace directory: %w", err)
-	}
+        currentDirectoryHash, err := directoryHashDeterministic(workspaceDir)
+        if err != nil {
+                return fmt.Errorf("failed to hash workspace directory: %w", err)
+        }
 
-	pgOpts := persistence.PostgresOpts{
-		URI: pgURI,
-	}
-	if err := persistence.InitPostgres(pgOpts); err != nil {
-		return fmt.Errorf("failed to initialize postgres connection: %w", err)
-	}
+        pgOpts := persistence.PostgresOpts{
+                URI: pgURI,
+        }
+        if err := persistence.InitPostgres(pgOpts); err != nil {
+                return fmt.Errorf("failed to initialize postgres connection: %w", err)
+        }
 
-	conn := persistence.MustGetPooledPostgresSession()
-	defer conn.Release()
+        conn := persistence.MustGetPooledPostgresSession()
+        defer conn.Release()
 
-	// since we do want to support multiple bootstrap workspaces, we generate a key for each
+        // since we do want to support multiple bootstrap workspaces, we generate a key for each
 
-	query := `select value from bootstrap_meta where key = 'current_directory_hash' and workspace_id = $1`
-	row := conn.QueryRow(ctx, query, workspaceID)
-	var lastDirectoryHash sql.NullString
-	err = row.Scan(&lastDirectoryHash)
-	if err != nil && err != pgx.ErrNoRows {
-		return fmt.Errorf("failed to get last directory hash: %w", err)
-	}
+        query := `select value from bootstrap_meta where key = 'current_directory_hash' and workspace_id = $1`
+        row := conn.QueryRow(ctx, query, workspaceID)
+        var lastDirectoryHash sql.NullString
+        err = row.Scan(&lastDirectoryHash)
+        if err != nil && err != pgx.ErrNoRows {
+                return fmt.Errorf("failed to get last directory hash: %w", err)
+        }
 
-	if !force && lastDirectoryHash.Valid && lastDirectoryHash.String == currentDirectoryHash {
-		fmt.Printf("Bootstrap directory hash is the same as last time, skipping bootstrap\n")
-		return nil
-	}
+        if !force && lastDirectoryHash.Valid && lastDirectoryHash.String == currentDirectoryHash {
+                fmt.Printf("Bootstrap directory hash is the same as last time, skipping bootstrap\n")
+                return nil
+        }
 
-	fmt.Printf("Bootstrapping initial workspace data from %s...\n", workspaceDir)
+        fmt.Printf("Bootstrapping initial workspace data from %s...\n", workspaceDir)
 
-	tx, err := conn.Begin(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to begin transaction: %w", err)
-	}
-	defer tx.Rollback(ctx)
+        tx, err := conn.Begin(ctx)
+        if err != nil {
+                return fmt.Errorf("failed to begin transaction: %w", err)
+        }
+        defer tx.Rollback(ctx)
 
-	// remove existing files
-	_, err = tx.Exec(ctx, "DELETE FROM bootstrap_file where workspace_id = $1", workspaceID)
-	if err != nil {
-		return fmt.Errorf("failed to delete files: %w", err)
-	}
+        // remove existing files
+        _, err = tx.Exec(ctx, "DELETE FROM bootstrap_file where workspace_id = $1", workspaceID)
+        if err != nil {
+                return fmt.Errorf("failed to delete files: %w", err)
+        }
 
-	// remove existing charts
-	_, err = tx.Exec(ctx, "DELETE FROM bootstrap_chart where workspace_id = $1", workspaceID)
-	if err != nil {
-		return fmt.Errorf("failed to delete charts: %w", err)
-	}
+        // remove existing charts
+        _, err = tx.Exec(ctx, "DELETE FROM bootstrap_chart where workspace_id = $1", workspaceID)
+        if err != nil {
+                return fmt.Errorf("failed to delete charts: %w", err)
+        }
 
-	_, err = tx.Exec(ctx, "INSERT INTO bootstrap_workspace (id, name, current_revision) VALUES ($1, $2, $3)", workspaceID, workspaceName, 0)
-	if err != nil {
-		return fmt.Errorf("failed to insert workspace: %w", err)
-	}
+        _, err = tx.Exec(ctx, "INSERT INTO bootstrap_workspace (id, name, current_revision) VALUES ($1, $2, $3)", workspaceID, workspaceName, 0)
+        if err != nil {
+                return fmt.Errorf("failed to insert workspace: %w", err)
+        }
 
-	_, err = tx.Exec(ctx, "INSERT INTO bootstrap_revision (workspace_id, revision_number, is_complete) VALUES ($1, $2, $3)", workspaceID, 0, true)
-	if err != nil {
-		return fmt.Errorf("failed to insert revision: %w", err)
-	}
+        _, err = tx.Exec(ctx, "INSERT INTO bootstrap_revision (workspace_id, revision_number, is_complete) VALUES ($1, $2, $3)", workspaceID, 0, true)
+        if err != nil {
+                return fmt.Errorf("failed to insert revision: %w", err)
+        }
 
-	charts := []string{}
-	chartsDir := filepath.Join(workspaceDir, "charts")
+        charts := []string{}
+        chartsDir := filepath.Join(workspaceDir, "charts")
 
-	entries, err := os.ReadDir(chartsDir)
-	if err != nil {
-		return fmt.Errorf("failed to read charts directory: %w", err)
-	}
+        entries, err := os.ReadDir(chartsDir)
+        if err != nil {
+                return fmt.Errorf("failed to read charts directory: %w", err)
+        }
 
-	for _, entry := range entries {
-		if entry.IsDir() {
-			charts = append(charts, filepath.Join(chartsDir, entry.Name()))
-		}
-	}
+        for _, entry := range entries {
+                if entry.IsDir() {
+                        charts = append(charts, filepath.Join(chartsDir, entry.Name()))
+                }
+        }
 
-	// for each chart in charts, walk and insert the files
-	for _, chart := range charts {
-		fmt.Printf("Processing chart %s...\n", chart)
+        // for each chart in charts, walk and insert the files
+        for _, chart := range charts {
+                fmt.Printf("Processing chart %s...\n", chart)
 
-		chartID := hashString(chart)
-		chartName := ""
+                chartID := hashString(chart)
+                chartName := ""
 
-		// walk the chart directory and insert files
-		err = filepath.Walk(chart, func(path string, info os.FileInfo, err error) error {
-			if err != nil {
-				return fmt.Errorf("failed to walk chart directory: %w", err)
-			}
-			if info.IsDir() {
-				return nil
-			}
+                // walk the chart directory and insert files
+                err = filepath.Walk(chart, func(path string, info os.FileInfo, err error) error {
+                        if err != nil {
+                                return fmt.Errorf("failed to walk chart directory: %w", err)
+                        }
+                        if info.IsDir() {
+                                return nil
+                        }
 
-			content, err := os.ReadFile(path)
-			if err != nil {
-				return fmt.Errorf("failed to read file: %w", err)
-			}
+                        content, err := os.ReadFile(path)
+                        if err != nil {
+                                return fmt.Errorf("failed to read file: %w", err)
+                        }
 
-			relativePath := strings.TrimPrefix(path, chart)
-			relativePath = strings.TrimPrefix(relativePath, string(os.PathSeparator))
+                        relativePath := strings.TrimPrefix(path, chart)
+                        relativePath = strings.TrimPrefix(relativePath, string(os.PathSeparator))
 
-			if relativePath == "Chart.yaml" {
-				// parse and get the chart name
-				n, err := parseChartName(string(content))
-				if err != nil {
-					return fmt.Errorf("failed to parse chart name: %w", err)
-				}
-				chartName = n
-			}
+                        if relativePath == "Chart.yaml" {
+                                // parse and get the chart name
+                                n, err := parseChartName(string(content))
+                                if err != nil {
+                                        return fmt.Errorf("failed to parse chart name: %w", err)
+                                }
+                                chartName = n
+                        }
 
-			fmt.Printf("summarizing %s...\n", relativePath)
-			summary, err := llm.SummarizeContent(ctx, string(content))
-			if err != nil {
-				return fmt.Errorf("failed to summarize GVK: %w", err)
-			}
+                        fmt.Printf("summarizing %s...\n", relativePath)
+                        summary, err := llm.SummarizeContent(ctx, string(content))
+                        if err != nil {
+                                return fmt.Errorf("failed to summarize GVK: %w", err)
+                        }
 
-			fmt.Printf("embedding %s...\n", relativePath)
-			embeddings, err := embedding.Embeddings(summary)
-			if err != nil {
-				return fmt.Errorf("failed to get embeddings: %w", err)
-			}
+                        fmt.Printf("embedding %s...\n", relativePath)
+                        embeddings, err := embedding.Embeddings(summary)
+                        if err != nil {
+                                return fmt.Errorf("failed to get embeddings: %w", err)
+                        }
 
-			_, err = tx.Exec(ctx, `
-				INSERT INTO bootstrap_file (id, chart_id, workspace_id, file_path, content, summary, embeddings)
-				VALUES ($1, $2, $3, $4, $5, $6, $7)
-			`, hashString(relativePath), chartID, workspaceID, relativePath, content, summary, embeddings)
-			if err != nil {
-				return fmt.Errorf("failed to insert file: %w", err)
-			}
+                        _, err = tx.Exec(ctx, `
+                                INSERT INTO bootstrap_file (id, chart_id, workspace_id, file_path, content, summary, embeddings)
+                                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                        `, hashString(relativePath), chartID, workspaceID, relativePath, content, summary, embeddings)
+                        if err != nil {
+                                return fmt.Errorf("failed to insert file: %w", err)
+                        }
 
-			return nil
-		})
-		if err != nil {
-			return fmt.Errorf("failed to insert chart files: %w", err)
-		}
+                        return nil
+                })
+                if err != nil {
+                        return fmt.Errorf("failed to insert chart files: %w", err)
+                }
 
-		_, err := tx.Exec(ctx, `
+                _, err := tx.Exec(ctx, `
             INSERT INTO bootstrap_chart (id, workspace_id, name)
             VALUES ($1, $2, $3)
         `, chartID, workspaceID, chartName)
-		if err != nil {
-			return fmt.Errorf("failed to insert chart: %w", err)
-		}
-	}
+                if err != nil {
+                        return fmt.Errorf("failed to insert chart: %w", err)
+                }
+        }
 
-	if err := tx.Commit(ctx); err != nil {
-		return fmt.Errorf("failed to commit transaction: %w", err)
-	}
+        if err := tx.Commit(ctx); err != nil {
+                return fmt.Errorf("failed to commit transaction: %w", err)
+        }
 
-	// store the current directory hash
-	_, err = conn.Exec(ctx, `
+        // store the current directory hash
+        _, err = conn.Exec(ctx, `
         INSERT INTO bootstrap_meta (key, value, workspace_id)
         VALUES ('current_directory_hash', $1, $2)
-		ON CONFLICT (key, workspace_id) DO UPDATE SET value = $1
+                ON CONFLICT (key, workspace_id) DO UPDATE SET value = $1
     `, currentDirectoryHash, workspaceID)
-	if err != nil {
-		return fmt.Errorf("failed to store current directory hash: %w", err)
-	}
+        if err != nil {
+                return fmt.Errorf("failed to store current directory hash: %w", err)
+        }
 
-	return nil
+        return nil
 }
 
 func directoryHashDeterministic(path string) (string, error) {
-	var files []string
-	err := filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		relPath, err := filepath.Rel(path, filePath)
-		if err != nil {
-			return err
-		}
-		if relPath != "." {
-			files = append(files, relPath)
-		}
-		return nil
-	})
-	if err != nil {
-		return "", fmt.Errorf("failed to walk directory: %w", err)
-	}
+        var files []string
+        err := filepath.Walk(path, func(filePath string, info os.FileInfo, err error) error {
+                if err != nil {
+                        return fmt.Errorf("failed to walk directory: %w", err)
+                }
+                relPath, err := filepath.Rel(path, filePath)
+                if err != nil {
+                        return fmt.Errorf("failed to get relative path: %w", err)
+                }
+                if relPath != "." {
+                        files = append(files, relPath)
+                }
+                return nil
+        })
+        if err != nil {
+                return "", fmt.Errorf("failed to walk directory: %w", err)
+        }
 
-	// Sort files for deterministic ordering
-	sort.Strings(files)
+        // Sort files for deterministic ordering
+        sort.Strings(files)
 
-	hasher := sha256.New()
-	for _, relPath := range files {
-		filePath := filepath.Join(path, relPath)
-		info, err := os.Stat(filePath)
-		if err != nil {
-			return "", fmt.Errorf("failed to stat file %s: %w", filePath, err)
-		}
+        hasher := sha256.New()
+        for _, relPath := range files {
+                filePath := filepath.Join(path, relPath)
+                info, err := os.Stat(filePath)
+                if err != nil {
+                        return "", fmt.Errorf("failed to stat file %s: %w", filePath, err)
+                }
 
-		// Hash the relative path
-		if _, err := hasher.Write([]byte(relPath)); err != nil {
-			return "", fmt.Errorf("failed to hash path: %w", err)
-		}
+                // Hash the relative path
+                if _, err := hasher.Write([]byte(relPath)); err != nil {
+                        return "", fmt.Errorf("failed to hash path: %w", err)
+                }
 
-		// If it's a regular file, hash its contents
-		if info.Mode().IsRegular() {
-			file, err := os.Open(filePath)
-			if err != nil {
-				return "", fmt.Errorf("failed to open file %s: %w", filePath, err)
-			}
+                // If it's a regular file, hash its contents
+                if info.Mode().IsRegular() {
+                        file, err := os.Open(filePath)
+                        if err != nil {
+                                return "", fmt.Errorf("failed to open file %s: %w", filePath, err)
+                        }
 
-			if _, err := io.Copy(hasher, file); err != nil {
-				file.Close()
-				return "", fmt.Errorf("failed to hash file %s: %w", filePath, err)
-			}
-			file.Close()
-		}
+                        if _, err := io.Copy(hasher, file); err != nil {
+                                file.Close()
+                                return "", fmt.Errorf("failed to hash file %s: %w", filePath, err)
+                        }
+                        file.Close()
+                }
 
-		// Hash file metadata
-		modeBytes := []byte(fmt.Sprintf("%v", info.Mode()))
-		sizeBytes := []byte(fmt.Sprintf("%d", info.Size()))
+                // Hash file metadata
+                modeBytes := []byte(fmt.Sprintf("%v", info.Mode()))
+                sizeBytes := []byte(fmt.Sprintf("%d", info.Size()))
 
-		if _, err := hasher.Write(modeBytes); err != nil {
-			return "", fmt.Errorf("failed to hash file mode: %w", err)
-		}
-		if _, err := hasher.Write(sizeBytes); err != nil {
-			return "", fmt.Errorf("failed to hash file size: %w", err)
-		}
-	}
+                if _, err := hasher.Write(modeBytes); err != nil {
+                        return "", fmt.Errorf("failed to hash file mode: %w", err)
+                }
+                if _, err := hasher.Write(sizeBytes); err != nil {
+                        return "", fmt.Errorf("failed to hash file size: %w", err)
+                }
+        }
 
-	return hex.EncodeToString(hasher.Sum(nil)), nil
+        return hex.EncodeToString(hasher.Sum(nil)), nil
 }
 
 func hashString(s string) string {
-	h := fnv.New32a()
-	h.Write([]byte(s))
-	return fmt.Sprintf("%04x", uint16(h.Sum32()))
+        h := fnv.New32a()
+        h.Write([]byte(s))
+        return fmt.Sprintf("%04x", uint16(h.Sum32()))
 }
 
 func parseChartName(chartYAML string) (string, error) {
-	var chart struct {
-		Name string `yaml:"name"`
-	}
+        var chart struct {
+                Name string `yaml:"name"`
+        }
 
-	err := yaml.Unmarshal([]byte(chartYAML), &chart)
-	if err != nil {
-		return "", fmt.Errorf("failed to parse chart.yaml: %w", err)
-	}
+        err := yaml.Unmarshal([]byte(chartYAML), &chart)
+        if err != nil {
+                return "", fmt.Errorf("failed to parse chart.yaml: %w", err)
+        }
 
-	return chart.Name, nil
+        return chart.Name, nil
 }

--- a/dagger/gitops.go
+++ b/dagger/gitops.go
@@ -1,60 +1,60 @@
 package main
 
 import (
-	"context"
-	"dagger/chartsmith/internal/dagger"
-	"fmt"
+        "context"
+        "dagger/chartsmith/internal/dagger"
+        "fmt"
 )
 
 type PushFileOpts struct {
-	RepoFullName    string // "org/repo"
-	Branch          string // e.g. "main"
-	DestinationPath string // where to put the file in the repo
-	CommitMessage   string // commit message
-	GithubToken     *dagger.Secret
+        RepoFullName    string // "org/repo"
+        Branch          string // e.g. "main"
+        DestinationPath string // where to put the file in the repo
+        CommitMessage   string // commit message
+        GithubToken     *dagger.Secret
 }
 
 func pushYAMLsToRepo(ctx context.Context, yamlFiles *dagger.Directory, opts PushFileOpts) error {
-	// join all files into a single yaml file with --- separators
+        // join all files into a single yaml file with --- separators
 
-	merged := ""
+        merged := ""
 
-	entries, err := yamlFiles.Entries(ctx)
-	if err != nil {
-		return err
-	}
-	for _, entry := range entries {
-		contents, err := yamlFiles.File(entry).Contents(ctx)
-		if err != nil {
-			return err
-		}
+        entries, err := yamlFiles.Entries(ctx)
+        if err != nil {
+                return fmt.Errorf("failed to get directory entries: %w", err)
+        }
+        for _, entry := range entries {
+                contents, err := yamlFiles.File(entry).Contents(ctx)
+                if err != nil {
+                        return fmt.Errorf("failed to read file contents for %s: %w", entry, err)
+                }
 
-		merged += fmt.Sprintf("---\n%s\n", contents)
-	}
+                merged += fmt.Sprintf("---\n%s\n", contents)
+        }
 
-	yamlFile := dagger.Connect().Directory().WithNewFile("merged.yaml", merged).File("merged.yaml")
+        yamlFile := dagger.Connect().Directory().WithNewFile("merged.yaml", merged).File("merged.yaml")
 
-	return pushYAMLToRepo(ctx, yamlFile, opts)
+        return pushYAMLToRepo(ctx, yamlFile, opts)
 }
 
 func pushYAMLToRepo(ctx context.Context, yamlFile *dagger.File, opts PushFileOpts) error {
-	client := dagger.Connect()
+        client := dagger.Connect()
 
-	container := client.Container().
-		From("alpine/git").
-		WithMountedFile("/tmp/file.yaml", yamlFile).
-		WithEnvVariable("GIT_AUTHOR_NAME", "Chartsmith Dagger").
-		WithEnvVariable("GIT_AUTHOR_EMAIL", "release@replicated.com").
-		WithEnvVariable("GIT_COMMITTER_NAME", "Chartsmith Dagger").
-		WithEnvVariable("GIT_COMMITTER_EMAIL", "release@replicated.com")
+        container := client.Container().
+                From("alpine/git").
+                WithMountedFile("/tmp/file.yaml", yamlFile).
+                WithEnvVariable("GIT_AUTHOR_NAME", "Chartsmith Dagger").
+                WithEnvVariable("GIT_AUTHOR_EMAIL", "release@replicated.com").
+                WithEnvVariable("GIT_COMMITTER_NAME", "Chartsmith Dagger").
+                WithEnvVariable("GIT_COMMITTER_EMAIL", "release@replicated.com")
 
-	// Set up Git with credentials
-	container = container.WithSecretVariable("GITHUB_TOKEN", opts.GithubToken)
+        // Set up Git with credentials
+        container = container.WithSecretVariable("GITHUB_TOKEN", opts.GithubToken)
 
-	// Clone, add file, commit and push
-	stdout, err := container.WithExec([]string{
-		"sh", "-c",
-		fmt.Sprintf(`
+        // Clone, add file, commit and push
+        stdout, err := container.WithExec([]string{
+                "sh", "-c",
+                fmt.Sprintf(`
             git clone https://oauth2:${GITHUB_TOKEN}@github.com/%s.git repo &&
             cd repo &&
             cp /tmp/file.yaml %s &&
@@ -67,14 +67,17 @@ func pushYAMLToRepo(ctx context.Context, yamlFile *dagger.File, opts PushFileOpt
                 git push origin %s
             fi
         `,
-			opts.RepoFullName,
-			opts.DestinationPath,
-			opts.DestinationPath,
-			opts.CommitMessage,
-			opts.Branch,
-		),
-	}).Stdout(ctx)
-	fmt.Printf("%s\n", stdout)
+                        opts.RepoFullName,
+                        opts.DestinationPath,
+                        opts.DestinationPath,
+                        opts.CommitMessage,
+                        opts.Branch,
+                ),
+        }).Stdout(ctx)
+        fmt.Printf("%s\n", stdout)
 
-	return err
+        if err != nil {
+                return fmt.Errorf("failed to push changes to repository: %w", err)
+        }
+        return nil
 }

--- a/dagger/release.go
+++ b/dagger/release.go
@@ -1,187 +1,187 @@
 package main
 
 import (
-	"context"
-	"dagger/chartsmith/internal/dagger"
-	"fmt"
+        "context"
+        "dagger/chartsmith/internal/dagger"
+        "fmt"
 )
 
 func (m *Chartsmith) Release(
-	ctx context.Context,
+        ctx context.Context,
 
-	// +defaultPath="/"
-	source *dagger.Directory,
+        // +defaultPath="/"
+        source *dagger.Directory,
 
-	version string,
-	githubToken *dagger.Secret,
-	opServiceAccount *dagger.Secret,
+        version string,
+        githubToken *dagger.Secret,
+        opServiceAccount *dagger.Secret,
 ) error {
-	latestVersion, newVersion, err := processVersion(ctx, version, githubToken)
-	if err != nil {
-		return fmt.Errorf("processing version: %w", err)
-	}
+        latestVersion, newVersion, err := processVersion(ctx, version, githubToken)
+        if err != nil {
+                return fmt.Errorf("processing version: %w", err)
+        }
 
-	fmt.Printf("Releasing %s -> %s\n", latestVersion, newVersion)
+        fmt.Printf("Releasing %s -> %s\n", latestVersion, newVersion)
 
-	if err := pushTag(ctx, source, githubToken, newVersion); err != nil {
-		return err
-	}
+        if err := pushTag(ctx, source, githubToken, newVersion); err != nil {
+                return fmt.Errorf("failed to push tag: %w", err)
+        }
 
-	stagingAccountID := mustGetNonSensitiveSecret(ctx, opServiceAccount, "Chartsmith - Staging Push", "account_id")
-	stagingAccessKeyID := mustGetNonSensitiveSecret(ctx, opServiceAccount, "Chartsmith - Staging Push", "access_key_id")
-	stagingSecretAccessKey := mustGetSecret(ctx, opServiceAccount, "Chartsmith - Staging Push", "secret_access_key")
+        stagingAccountID := mustGetNonSensitiveSecret(ctx, opServiceAccount, "Chartsmith - Staging Push", "account_id")
+        stagingAccessKeyID := mustGetNonSensitiveSecret(ctx, opServiceAccount, "Chartsmith - Staging Push", "access_key_id")
+        stagingSecretAccessKey := mustGetSecret(ctx, opServiceAccount, "Chartsmith - Staging Push", "secret_access_key")
 
-	productionAccountID := mustGetNonSensitiveSecret(ctx, opServiceAccount, "Chartsmith - Production Push", "account_id")
-	productionAccessKeyID := mustGetNonSensitiveSecret(ctx, opServiceAccount, "Chartsmith - Production Push", "access_key_id")
-	productionSecretAccessKey := mustGetSecret(ctx, opServiceAccount, "Chartsmith - Production Push", "secret_access_key")
+        productionAccountID := mustGetNonSensitiveSecret(ctx, opServiceAccount, "Chartsmith - Production Push", "account_id")
+        productionAccessKeyID := mustGetNonSensitiveSecret(ctx, opServiceAccount, "Chartsmith - Production Push", "access_key_id")
+        productionSecretAccessKey := mustGetSecret(ctx, opServiceAccount, "Chartsmith - Production Push", "secret_access_key")
 
-	// build all containers
-	workerContainerStaging, workerContainerProd, err := buildWorker(ctx, source)
-	if err != nil {
-		return err
-	}
+        // build all containers
+        workerContainerStaging, workerContainerProd, err := buildWorker(ctx, source)
+        if err != nil {
+                return fmt.Errorf("failed to build worker containers: %w", err)
+        }
 
-	appContainerStaging, appContainerProd, err := buildChartsmithApp(ctx, source.Directory("chartsmith-app"), opServiceAccount, newVersion)
-	if err != nil {
-		return err
-	}
+        appContainerStaging, appContainerProd, err := buildChartsmithApp(ctx, source.Directory("chartsmith-app"), opServiceAccount, newVersion)
+        if err != nil {
+                return fmt.Errorf("failed to build Chartsmith app containers: %w", err)
+        }
 
-	// publish all containers
-	ref, err := pushContainer(ctx, workerContainerStaging, PushContainerOpts{
-		Name:      "chartsmith-worker",
-		Tag:       newVersion,
-		AccountID: stagingAccountID,
-		Region:    "us-east-1",
+        // publish all containers
+        ref, err := pushContainer(ctx, workerContainerStaging, PushContainerOpts{
+                Name:      "chartsmith-worker",
+                Tag:       newVersion,
+                AccountID: stagingAccountID,
+                Region:    "us-east-1",
 
-		AccessKeyID:     stagingAccessKeyID,
-		SecretAccessKey: stagingSecretAccessKey,
-	})
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Pushed %s\n", ref)
+                AccessKeyID:     stagingAccessKeyID,
+                SecretAccessKey: stagingSecretAccessKey,
+        })
+        if err != nil {
+                return fmt.Errorf("failed to push staging worker container: %w", err)
+        }
+        fmt.Printf("Pushed %s\n", ref)
 
-	ref, err = pushContainer(ctx, workerContainerProd, PushContainerOpts{
-		Name:      "chartsmith-worker",
-		Tag:       newVersion,
-		AccountID: productionAccountID,
-		Region:    "us-east-1",
+        ref, err = pushContainer(ctx, workerContainerProd, PushContainerOpts{
+                Name:      "chartsmith-worker",
+                Tag:       newVersion,
+                AccountID: productionAccountID,
+                Region:    "us-east-1",
 
-		AccessKeyID:     productionAccessKeyID,
-		SecretAccessKey: productionSecretAccessKey,
-	})
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Pushed %s\n", ref)
+                AccessKeyID:     productionAccessKeyID,
+                SecretAccessKey: productionSecretAccessKey,
+        })
+        if err != nil {
+                return fmt.Errorf("failed to push production worker container: %w", err)
+        }
+        fmt.Printf("Pushed %s\n", ref)
 
-	ref, err = pushContainer(ctx, appContainerStaging, PushContainerOpts{
-		Name:      "chartsmith-app",
-		Tag:       newVersion,
-		AccountID: stagingAccountID,
-		Region:    "us-east-1",
+        ref, err = pushContainer(ctx, appContainerStaging, PushContainerOpts{
+                Name:      "chartsmith-app",
+                Tag:       newVersion,
+                AccountID: stagingAccountID,
+                Region:    "us-east-1",
 
-		AccessKeyID:     stagingAccessKeyID,
-		SecretAccessKey: stagingSecretAccessKey,
-	})
-	if err != nil {
-		return err
-	}
-	fmt.Printf("Pushed %s\n", ref)
+                AccessKeyID:     stagingAccessKeyID,
+                SecretAccessKey: stagingSecretAccessKey,
+        })
+        if err != nil {
+                return fmt.Errorf("failed to push staging app container: %w", err)
+        }
+        fmt.Printf("Pushed %s\n", ref)
 
-	ref, err = pushContainer(ctx, appContainerProd, PushContainerOpts{
-		Name:      "chartsmith-app",
-		Tag:       newVersion,
-		AccountID: productionAccountID,
-		Region:    "us-east-1",
+        ref, err = pushContainer(ctx, appContainerProd, PushContainerOpts{
+                Name:      "chartsmith-app",
+                Tag:       newVersion,
+                AccountID: productionAccountID,
+                Region:    "us-east-1",
 
-		AccessKeyID:     productionAccessKeyID,
-		SecretAccessKey: productionSecretAccessKey,
-	})
-	if err != nil {
-		return err
-	}
+                AccessKeyID:     productionAccessKeyID,
+                SecretAccessKey: productionSecretAccessKey,
+        })
+        if err != nil {
+                return fmt.Errorf("failed to push production app container: %w", err)
+        }
 
-	databaseFile := source.File("db/database.yaml")
-	if err := pushYAMLToRepo(ctx, databaseFile, PushFileOpts{
-		RepoFullName:    "replicatedcom/gitops-deploy",
-		Branch:          "main",
-		DestinationPath: "chartsmith/database.yaml",
-		CommitMessage:   fmt.Sprintf("Update Chartsmith database to %s", newVersion),
-		GithubToken:     githubToken,
-	}); err != nil {
-		return err
-	}
+        databaseFile := source.File("db/database.yaml")
+        if err := pushYAMLToRepo(ctx, databaseFile, PushFileOpts{
+                RepoFullName:    "replicatedcom/gitops-deploy",
+                Branch:          "main",
+                DestinationPath: "chartsmith/database.yaml",
+                CommitMessage:   fmt.Sprintf("Update Chartsmith database to %s", newVersion),
+                GithubToken:     githubToken,
+        }); err != nil {
+                return fmt.Errorf("failed to push database YAML: %w", err)
+        }
 
-	migrations := getChartsmithMigrations(ctx, source)
-	if err := pushYAMLsToRepo(ctx, migrations, PushFileOpts{
-		RepoFullName:    "replicatedcom/gitops-deploy",
-		Branch:          "main",
-		DestinationPath: "chartsmith/migrations.yaml",
-		CommitMessage:   fmt.Sprintf("Update Chartsmith database to %s", newVersion),
-		GithubToken:     githubToken,
-	}); err != nil {
-		return err
-	}
+        migrations := getChartsmithMigrations(ctx, source)
+        if err := pushYAMLsToRepo(ctx, migrations, PushFileOpts{
+                RepoFullName:    "replicatedcom/gitops-deploy",
+                Branch:          "main",
+                DestinationPath: "chartsmith/migrations.yaml",
+                CommitMessage:   fmt.Sprintf("Update Chartsmith database to %s", newVersion),
+                GithubToken:     githubToken,
+        }); err != nil {
+                return fmt.Errorf("failed to push migrations YAML: %w", err)
+        }
 
-	stagingHostname := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", stagingAccountID, "us-east-1")
-	appImageName := fmt.Sprintf("%s/%s:%s", stagingHostname, "chartsmith-app", newVersion)
-	workerImageName := fmt.Sprintf("%s/%s:%s", stagingHostname, "chartsmith-worker", newVersion)
+        stagingHostname := fmt.Sprintf("%s.dkr.ecr.%s.amazonaws.com", stagingAccountID, "us-east-1")
+        appImageName := fmt.Sprintf("%s/%s:%s", stagingHostname, "chartsmith-app", newVersion)
+        workerImageName := fmt.Sprintf("%s/%s:%s", stagingHostname, "chartsmith-worker", newVersion)
 
-	stagingEditedSource := dag.
-		Kustomize().
-		Edit(source, dagger.KustomizeEditOpts{
-			Dir: "kustomize/overlays/staging",
-		}).
-		Set().
-		Namespace("chartsmith").
-		Set().
-		Image(fmt.Sprintf("chartsmith-worker=%s", workerImageName)).
-		Set().
-		Image(fmt.Sprintf("chartsmith-app=%s", appImageName)).
-		Directory()
+        stagingEditedSource := dag.
+                Kustomize().
+                Edit(source, dagger.KustomizeEditOpts{
+                        Dir: "kustomize/overlays/staging",
+                }).
+                Set().
+                Namespace("chartsmith").
+                Set().
+                Image(fmt.Sprintf("chartsmith-worker=%s", workerImageName)).
+                Set().
+                Image(fmt.Sprintf("chartsmith-app=%s", appImageName)).
+                Directory()
 
-	stagingManifests := dag.Kustomize().Build(
-		stagingEditedSource,
-		dagger.KustomizeBuildOpts{
-			Dir: "kustomize/overlays/staging",
-		},
-	)
+        stagingManifests := dag.Kustomize().Build(
+                stagingEditedSource,
+                dagger.KustomizeBuildOpts{
+                        Dir: "kustomize/overlays/staging",
+                },
+        )
 
-	if err := pushYAMLToRepo(ctx, stagingManifests, PushFileOpts{
-		RepoFullName:    "replicatedcom/gitops-deploy",
-		Branch:          "main",
-		DestinationPath: "chartsmith/chartsmith.yaml",
-		CommitMessage:   fmt.Sprintf("Update Chartsmith manifests to %s", newVersion),
-		GithubToken:     githubToken,
-	}); err != nil {
-		return err
-	}
+        if err := pushYAMLToRepo(ctx, stagingManifests, PushFileOpts{
+                RepoFullName:    "replicatedcom/gitops-deploy",
+                Branch:          "main",
+                DestinationPath: "chartsmith/chartsmith.yaml",
+                CommitMessage:   fmt.Sprintf("Update Chartsmith manifests to %s", newVersion),
+                GithubToken:     githubToken,
+        }); err != nil {
+                return fmt.Errorf("failed to push staging manifests: %w", err)
+        }
 
-	// productionMergedManifests := dag.
-	// 	Kustomize().
-	// 	Build(source, dagger.KustomizeBuildOpts{
-	// 		Dir: "kustomize/overlays/production",
-	// 	})
-	// if err := pushYAMLToRepo(ctx, productionMergedManifests, PushFileOpts{
-	// 	RepoFullName:    "replicatedcom/gitops-deploy",
-	// 	Branch:          "release",
-	// 	DestinationPath: "chartsmith.yaml",
-	// 	CommitMessage:   fmt.Sprintf("Update Chartsmith manifests to %s", newVersion),
-	// 	GithubToken:     githubToken,
-	// }); err != nil {
-	// 	return err
-	// }
+        // productionMergedManifests := dag.
+        //      Kustomize().
+        //      Build(source, dagger.KustomizeBuildOpts{
+        //              Dir: "kustomize/overlays/production",
+        //      })
+        // if err := pushYAMLToRepo(ctx, productionMergedManifests, PushFileOpts{
+        //      RepoFullName:    "replicatedcom/gitops-deploy",
+        //      Branch:          "release",
+        //      DestinationPath: "chartsmith.yaml",
+        //      CommitMessage:   fmt.Sprintf("Update Chartsmith manifests to %s", newVersion),
+        //      GithubToken:     githubToken,
+        // }); err != nil {
+        //      return err
+        // }
 
-	// create a release on github
-	if err := dag.Gh().
-		WithToken(githubToken).
-		WithRepo("replicatedhq/chartsmith").
-		WithSource(source).
-		Release().
-		Create(ctx, newVersion, newVersion); err != nil {
-		return err
-	}
+        // create a release on github
+        if err := dag.Gh().
+                WithToken(githubToken).
+                WithRepo("replicatedhq/chartsmith").
+                WithSource(source).
+                Release().
+                Create(ctx, newVersion, newVersion); err != nil {
+                return fmt.Errorf("failed to create GitHub release: %w", err)
+        }
 
-	return nil
+        return nil
 }

--- a/pkg/listener/execute-plan.go
+++ b/pkg/listener/execute-plan.go
@@ -1,167 +1,167 @@
 package listener
 
 import (
-	"context"
-	"fmt"
-	"strings"
+        "context"
+        "fmt"
+        "strings"
 
-	"github.com/replicatedhq/chartsmith/pkg/llm"
-	llmtypes "github.com/replicatedhq/chartsmith/pkg/llm/types"
-	"github.com/replicatedhq/chartsmith/pkg/persistence"
-	"github.com/replicatedhq/chartsmith/pkg/realtime"
-	realtimetypes "github.com/replicatedhq/chartsmith/pkg/realtime/types"
-	"github.com/replicatedhq/chartsmith/pkg/workspace"
-	workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
+        "github.com/replicatedhq/chartsmith/pkg/llm"
+        llmtypes "github.com/replicatedhq/chartsmith/pkg/llm/types"
+        "github.com/replicatedhq/chartsmith/pkg/persistence"
+        "github.com/replicatedhq/chartsmith/pkg/realtime"
+        realtimetypes "github.com/replicatedhq/chartsmith/pkg/realtime/types"
+        "github.com/replicatedhq/chartsmith/pkg/workspace"
+        workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
 )
 
 func sendExecuteActionNotification(ctx context.Context, planID string, path string) error {
-	notifyConn := persistence.MustGeUunpooledPostgresSession()
-	defer notifyConn.Close(ctx)
+        notifyConn := persistence.MustGeUunpooledPostgresSession()
+        defer notifyConn.Close(ctx)
 
-	// Insert into queue with just the required fields
-	if _, err := notifyConn.Exec(ctx, `
-		INSERT INTO action_queue (plan_id, path, created_at)
-		VALUES ($1, $2, NOW())
-		ON CONFLICT (plan_id, path) DO NOTHING
-	`, planID, path); err != nil {
-		return fmt.Errorf("failed to queue action: %w", err)
-	}
+        // Insert into queue with just the required fields
+        if _, err := notifyConn.Exec(ctx, `
+                INSERT INTO action_queue (plan_id, path, created_at)
+                VALUES ($1, $2, NOW())
+                ON CONFLICT (plan_id, path) DO NOTHING
+        `, planID, path); err != nil {
+                return fmt.Errorf("failed to queue action: %w", err)
+        }
 
-	// Notify to wake up any sleeping workers
-	if _, err := notifyConn.Exec(ctx, `
-		SELECT pg_notify('execute_action', 'new')
-	`); err != nil {
-		return fmt.Errorf("failed to send execute action notification: %w", err)
-	}
-	return nil
+        // Notify to wake up any sleeping workers
+        if _, err := notifyConn.Exec(ctx, `
+                SELECT pg_notify('execute_action', 'new')
+        `); err != nil {
+                return fmt.Errorf("failed to send execute action notification: %w", err)
+        }
+        return nil
 }
 
 func handleExecutePlanNotification(ctx context.Context, planID string) error {
-	conn := persistence.MustGeUunpooledPostgresSession()
-	defer conn.Close(ctx)
+        conn := persistence.MustGeUunpooledPostgresSession()
+        defer conn.Close(ctx)
 
-	var processingErr error
-	defer func() {
-		var errorMsg *string
-		if processingErr != nil {
-			errStr := processingErr.Error()
-			errorMsg = &errStr
-		}
+        var processingErr error
+        defer func() {
+                var errorMsg *string
+                if processingErr != nil {
+                        errStr := processingErr.Error()
+                        errorMsg = &errStr
+                }
 
-		_, updateErr := conn.Exec(ctx, `
+                _, updateErr := conn.Exec(ctx, `
             UPDATE notification_processing
             SET processed_at = NOW(),
                 error = $1
             WHERE notification_channel = $2 and notification_id = $3
         `, errorMsg, "execute_plan", planID)
 
-		if updateErr != nil {
-			fmt.Printf("Failed to update notification status: %v\n", updateErr)
-		}
-	}()
+                if updateErr != nil {
+                        fmt.Printf("Failed to update notification status: %v\n", updateErr)
+                }
+        }()
 
-	fmt.Printf("Handling execute plan notification: %s\n", planID)
+        fmt.Printf("Handling execute plan notification: %s\n", planID)
 
-	plan, err := workspace.GetPlan(ctx, nil, planID)
-	if err != nil {
-		return fmt.Errorf("error getting plan: %w", err)
-	}
+        plan, err := workspace.GetPlan(ctx, nil, planID)
+        if err != nil {
+                return fmt.Errorf("error getting plan: %w", err)
+        }
 
-	w, err := workspace.GetWorkspace(ctx, plan.WorkspaceID)
-	if err != nil {
-		return fmt.Errorf("error getting workspace: %w", err)
-	}
+        w, err := workspace.GetWorkspace(ctx, plan.WorkspaceID)
+        if err != nil {
+                return fmt.Errorf("error getting workspace: %w", err)
+        }
 
-	userIDs, err := workspace.ListUserIDsForWorkspace(ctx, w.ID)
-	if err != nil {
-		return fmt.Errorf("error getting user IDs for workspace: %w", err)
-	}
+        userIDs, err := workspace.ListUserIDsForWorkspace(ctx, w.ID)
+        if err != nil {
+                return fmt.Errorf("error getting user IDs for workspace: %w", err)
+        }
 
-	realtimeRecipient := realtimetypes.Recipient{
-		UserIDs: userIDs,
-	}
+        realtimeRecipient := realtimetypes.Recipient{
+                UserIDs: userIDs,
+        }
 
-	if err := workspace.UpdatePlanStatus(ctx, plan.ID, workspacetypes.PlanStatusApplying); err != nil {
-		return fmt.Errorf("error updating plan status: %w", err)
-	}
+        if err := workspace.UpdatePlanStatus(ctx, plan.ID, workspacetypes.PlanStatusApplying); err != nil {
+                return fmt.Errorf("error updating plan status: %w", err)
+        }
 
-	plan.Status = workspacetypes.PlanStatusApplying
+        plan.Status = workspacetypes.PlanStatusApplying
 
-	e := realtimetypes.PlanUpdatedEvent{
-		WorkspaceID: w.ID,
-		Plan:        plan,
-	}
-	if err := realtime.SendEvent(ctx, realtimeRecipient, e); err != nil {
-		return fmt.Errorf("failed to send plan update: %w", err)
-	}
+        e := realtimetypes.PlanUpdatedEvent{
+                WorkspaceID: w.ID,
+                Plan:        plan,
+        }
+        if err := realtime.SendEvent(ctx, realtimeRecipient, e); err != nil {
+                return fmt.Errorf("failed to send plan update: %w", err)
+        }
 
-	detailedPlanStreamCh := make(chan string, 1)
-	detailedPlanActionCreatedCh := make(chan llmtypes.ActionPlanWithPath, 1)
-	detailedPlanDoneCh := make(chan error, 1)
-	go func() {
-		llm.CreateDetailedPlan(ctx, detailedPlanActionCreatedCh, detailedPlanStreamCh, detailedPlanDoneCh, plan)
-	}()
+        detailedPlanStreamCh := make(chan string, 1)
+        detailedPlanActionCreatedCh := make(chan llmtypes.ActionPlanWithPath, 1)
+        detailedPlanDoneCh := make(chan error, 1)
+        go func() {
+                llm.CreateDetailedPlan(ctx, detailedPlanActionCreatedCh, detailedPlanStreamCh, detailedPlanDoneCh, plan)
+        }()
 
-	var buffer strings.Builder
-	done := false
-	for !done {
-		select {
-		case stream := <-detailedPlanStreamCh:
-			// Trust the stream's spacing and just append
-			buffer.WriteString(stream)
+        var buffer strings.Builder
+        done := false
+        for !done {
+                select {
+                case stream := <-detailedPlanStreamCh:
+                        // Trust the stream's spacing and just append
+                        buffer.WriteString(stream)
 
-		case actionPlanWithPath := <-detailedPlanActionCreatedCh:
-			// get the plan from the db again, using a tx to lock
-			tx, err := conn.Begin(ctx)
-			if err != nil {
-				return fmt.Errorf("failed to begin transaction: %w", err)
-			}
-			defer tx.Rollback(ctx)
+                case actionPlanWithPath := <-detailedPlanActionCreatedCh:
+                        // get the plan from the db again, using a tx to lock
+                        tx, err := conn.Begin(ctx)
+                        if err != nil {
+                                return fmt.Errorf("failed to begin transaction: %w", err)
+                        }
+                        defer tx.Rollback(ctx)
 
-			currentPlan, err := workspace.GetPlan(ctx, tx, plan.ID)
-			if err != nil {
-				return fmt.Errorf("failed to get plan: %w", err)
-			}
-			if currentPlan.ActionFiles == nil {
-				currentPlan.ActionFiles = []workspacetypes.ActionFile{}
-			}
+                        currentPlan, err := workspace.GetPlan(ctx, tx, plan.ID)
+                        if err != nil {
+                                return fmt.Errorf("failed to get plan: %w", err)
+                        }
+                        if currentPlan.ActionFiles == nil {
+                                currentPlan.ActionFiles = []workspacetypes.ActionFile{}
+                        }
 
-			actionFile := workspacetypes.ActionFile{
-				Action: actionPlanWithPath.Action,
-				Path:   actionPlanWithPath.Path,
-				Status: string(llmtypes.ActionPlanStatusPending),
-			}
-			currentPlan.ActionFiles = append(currentPlan.ActionFiles, actionFile)
+                        actionFile := workspacetypes.ActionFile{
+                                Action: actionPlanWithPath.Action,
+                                Path:   actionPlanWithPath.Path,
+                                Status: string(llmtypes.ActionPlanStatusPending),
+                        }
+                        currentPlan.ActionFiles = append(currentPlan.ActionFiles, actionFile)
 
-			if err := workspace.UpdatePlanActionFiles(ctx, tx, currentPlan.ID, currentPlan.ActionFiles); err != nil {
-				return fmt.Errorf("error updating plan action files: %w", err)
-			}
+                        if err := workspace.UpdatePlanActionFiles(ctx, tx, currentPlan.ID, currentPlan.ActionFiles); err != nil {
+                                return fmt.Errorf("error updating plan action files: %w", err)
+                        }
 
-			if err := tx.Commit(ctx); err != nil {
-				return fmt.Errorf("failed to commit transaction: %w", err)
-			}
+                        if err := tx.Commit(ctx); err != nil {
+                                return fmt.Errorf("failed to commit transaction: %w", err)
+                        }
 
-			e := realtimetypes.PlanUpdatedEvent{
-				WorkspaceID: w.ID,
-				Plan:        currentPlan,
-			}
-			if err := realtime.SendEvent(ctx, realtimeRecipient, e); err != nil {
-				return fmt.Errorf("failed to send plan update: %w", err)
-			}
+                        e := realtimetypes.PlanUpdatedEvent{
+                                WorkspaceID: w.ID,
+                                Plan:        currentPlan,
+                        }
+                        if err := realtime.SendEvent(ctx, realtimeRecipient, e); err != nil {
+                                return fmt.Errorf("failed to send plan update: %w", err)
+                        }
 
-			// Send notification with a separate connection
-			if err := sendExecuteActionNotification(ctx, currentPlan.ID, actionPlanWithPath.Path); err != nil {
-				return err
-			}
+                        // Send notification with a separate connection
+                        if err := sendExecuteActionNotification(ctx, currentPlan.ID, actionPlanWithPath.Path); err != nil {
+                                return fmt.Errorf("failed to send execute action notification: %w", err)
+                        }
 
-		case err := <-detailedPlanDoneCh:
-			if err != nil {
-				return fmt.Errorf("error creating initial plan: %w", err)
-			}
+                case err := <-detailedPlanDoneCh:
+                        if err != nil {
+                                return fmt.Errorf("error creating initial plan: %w", err)
+                        }
 
-			done = true
-		}
-	}
+                        done = true
+                }
+        }
 
-	return nil
+        return nil
 }

--- a/pkg/listener/new-file.go
+++ b/pkg/listener/new-file.go
@@ -1,77 +1,77 @@
 package listener
 
 import (
-	"context"
-	"fmt"
-	"strconv"
-	"strings"
+        "context"
+        "fmt"
+        "strconv"
+        "strings"
 
-	"github.com/replicatedhq/chartsmith/pkg/embedding"
-	"github.com/replicatedhq/chartsmith/pkg/llm"
-	"github.com/replicatedhq/chartsmith/pkg/persistence"
-	"github.com/replicatedhq/chartsmith/pkg/workspace"
+        "github.com/replicatedhq/chartsmith/pkg/embedding"
+        "github.com/replicatedhq/chartsmith/pkg/llm"
+        "github.com/replicatedhq/chartsmith/pkg/persistence"
+        "github.com/replicatedhq/chartsmith/pkg/workspace"
 )
 
 func handleNewFileNotification(ctx context.Context, id string) error {
-	conn := persistence.MustGeUunpooledPostgresSession()
-	defer conn.Close(ctx)
+        conn := persistence.MustGeUunpooledPostgresSession()
+        defer conn.Close(ctx)
 
-	var processingErr error
-	defer func() {
-		var errorMsg *string
-		if processingErr != nil {
-			errStr := processingErr.Error()
-			errorMsg = &errStr
-		}
+        var processingErr error
+        defer func() {
+                var errorMsg *string
+                if processingErr != nil {
+                        errStr := processingErr.Error()
+                        errorMsg = &errStr
+                }
 
-		_, updateErr := conn.Exec(ctx, `
+                _, updateErr := conn.Exec(ctx, `
             UPDATE notification_processing
             SET processed_at = NOW(),
                 error = $1
             WHERE notification_channel = $2 and notification_id = $3
         `, errorMsg, "new_file", id)
 
-		if updateErr != nil {
-			fmt.Printf("Failed to update notification status: %v\n", updateErr)
-		}
-	}()
+                if updateErr != nil {
+                        fmt.Printf("Failed to update notification status: %v\n", updateErr)
+                }
+        }()
 
-	fmt.Printf("Handling new file notification: %s\n", id)
-	parts := strings.Split(id, "/")
-	fileID := parts[0]
-	revisionNumber, err := strconv.Atoi(parts[1])
-	if err != nil {
-		processingErr = err
-		return err
-	}
+        fmt.Printf("Handling new file notification: %s\n", id)
+        parts := strings.Split(id, "/")
+        fileID := parts[0]
+        revisionNumber, err := strconv.Atoi(parts[1])
+        if err != nil {
+                processingErr = fmt.Errorf("failed to parse revision number: %w", err)
+                return processingErr
+        }
 
-	fileRevision, err := workspace.GetFile(ctx, fileID, revisionNumber)
-	if err != nil {
-		processingErr = err
-		return err
-	}
+        fileRevision, err := workspace.GetFile(ctx, fileID, revisionNumber)
+        if err != nil {
+                processingErr = fmt.Errorf("failed to get file revision: %w", err)
+                return processingErr
+        }
 
-	if fileRevision.Summary != "" {
-		return nil
-	}
+        if fileRevision.Summary != "" {
+                return nil
+        }
 
-	summary, err := llm.SummarizeContent(ctx, fileRevision.Content)
-	if err != nil {
-		processingErr = err
-		return err
-	}
+        summary, err := llm.SummarizeContent(ctx, fileRevision.Content)
+        if err != nil {
+                processingErr = fmt.Errorf("failed to summarize content: %w", err)
+                return processingErr
+        }
 
-	embeddings, err := embedding.Embeddings(summary)
-	if err != nil {
-		processingErr = err
-		return err
-	}
+        embeddings, err := embedding.Embeddings(summary)
+        if err != nil {
+                processingErr = fmt.Errorf("failed to generate embeddings: %w", err)
+                return processingErr
+        }
 
-	err = workspace.SetFileSummaryAndEmbeddings(ctx, fileID, revisionNumber, summary, embeddings)
-	if err != nil {
-		processingErr = err
-		return err
-	}
+        err = workspace.SetFileSummaryAndEmbeddings(ctx, fileID, revisionNumber, summary, embeddings)
+        if err != nil {
+                processingErr = fmt.Errorf("failed to set file summary and embeddings: %w", err)
+                return processingErr
+        }
 
-	return nil
+        return nil
 }

--- a/pkg/listener/slack-notification.go
+++ b/pkg/listener/slack-notification.go
@@ -1,47 +1,47 @@
 package listener
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
 
-	"github.com/replicatedhq/chartsmith/pkg/persistence"
-	"github.com/replicatedhq/chartsmith/pkg/slack"
+        "github.com/replicatedhq/chartsmith/pkg/persistence"
+        "github.com/replicatedhq/chartsmith/pkg/slack"
 )
 
 func handleNewSlackNotification(ctx context.Context, id string) error {
-	conn := persistence.MustGeUunpooledPostgresSession()
-	defer conn.Close(ctx)
+        conn := persistence.MustGeUunpooledPostgresSession()
+        defer conn.Close(ctx)
 
-	var processingErr error
-	defer func() {
-		var errorMsg *string
-		if processingErr != nil {
-			errStr := processingErr.Error()
-			errorMsg = &errStr
-		}
+        var processingErr error
+        defer func() {
+                var errorMsg *string
+                if processingErr != nil {
+                        errStr := processingErr.Error()
+                        errorMsg = &errStr
+                }
 
-		_, updateErr := conn.Exec(ctx, `
+                _, updateErr := conn.Exec(ctx, `
             UPDATE notification_processing
             SET processed_at = NOW(),
                 error = $1
             WHERE notification_channel = $2 and notification_id = $3
         `, errorMsg, "new_slack_notification", id)
 
-		if updateErr != nil {
-			fmt.Printf("Failed to update notification status: %v\n", updateErr)
-		}
-	}()
+                if updateErr != nil {
+                        fmt.Printf("Failed to update notification status: %v\n", updateErr)
+                }
+        }()
 
-	slackNotification, err := slack.GetSlackNotification(ctx, id)
-	if err != nil {
-		processingErr = err
-		return err
-	}
+        slackNotification, err := slack.GetSlackNotification(ctx, id)
+        if err != nil {
+                processingErr = fmt.Errorf("failed to get Slack notification: %w", err)
+                return processingErr
+        }
 
-	if err := slack.SendNotificationToSlack(slackNotification); err != nil {
-		processingErr = err
-		return err
-	}
+        if err := slack.SendNotificationToSlack(slackNotification); err != nil {
+                processingErr = fmt.Errorf("failed to send notification to Slack: %w", err)
+                return processingErr
+        }
 
-	return nil
+        return nil
 }

--- a/pkg/llm/detailed-plan.go
+++ b/pkg/llm/detailed-plan.go
@@ -1,87 +1,87 @@
 package llm
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
 
-	anthropic "github.com/anthropics/anthropic-sdk-go"
-	types "github.com/replicatedhq/chartsmith/pkg/llm/types"
-	"github.com/replicatedhq/chartsmith/pkg/workspace"
-	workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
+        anthropic "github.com/anthropics/anthropic-sdk-go"
+        types "github.com/replicatedhq/chartsmith/pkg/llm/types"
+        "github.com/replicatedhq/chartsmith/pkg/workspace"
+        workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
 )
 
 func CreateDetailedPlan(ctx context.Context, planActionCreatedCh chan types.ActionPlanWithPath, streamCh chan string, doneCh chan error, plan *workspacetypes.Plan) error {
-	client, err := newAnthropicClient(ctx)
-	if err != nil {
-		return err
-	}
+        client, err := newAnthropicClient(ctx)
+        if err != nil {
+                return fmt.Errorf("failed to create Anthropic client: %w", err)
+        }
 
-	messages := []anthropic.MessageParam{
-		anthropic.NewAssistantMessage(anthropic.NewTextBlock(detailedPlanSystemPrompt)),
-		anthropic.NewUserMessage(anthropic.NewTextBlock(detailedPlanInstructions)),
-	}
+        messages := []anthropic.MessageParam{
+                anthropic.NewAssistantMessage(anthropic.NewTextBlock(detailedPlanSystemPrompt)),
+                anthropic.NewUserMessage(anthropic.NewTextBlock(detailedPlanInstructions)),
+        }
 
-	bootsrapChartUserMessage, err := summarizeBootstrapChart(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to summarize bootstrap chart: %w", err)
-	}
-	messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(bootsrapChartUserMessage)))
+        bootsrapChartUserMessage, err := summarizeBootstrapChart(ctx)
+        if err != nil {
+                return fmt.Errorf("failed to summarize bootstrap chart: %w", err)
+        }
+        messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(bootsrapChartUserMessage)))
 
-	messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(plan.Description)))
+        messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(plan.Description)))
 
-	stream := client.Messages.NewStreaming(context.TODO(), anthropic.MessageNewParams{
-		Model:     anthropic.F(anthropic.ModelClaude3_5Sonnet20241022),
-		MaxTokens: anthropic.F(int64(8192)),
-		Messages:  anthropic.F(messages),
-	})
+        stream := client.Messages.NewStreaming(context.TODO(), anthropic.MessageNewParams{
+                Model:     anthropic.F(anthropic.ModelClaude3_5Sonnet20241022),
+                MaxTokens: anthropic.F(int64(8192)),
+                Messages:  anthropic.F(messages),
+        })
 
-	fullResponseWithTags := ""
-	actionPlans := make(map[string]types.ActionPlan)
+        fullResponseWithTags := ""
+        actionPlans := make(map[string]types.ActionPlan)
 
-	message := anthropic.Message{}
-	for stream.Next() {
-		event := stream.Current()
-		message.Accumulate(event)
+        message := anthropic.Message{}
+        for stream.Next() {
+                event := stream.Current()
+                message.Accumulate(event)
 
-		switch delta := event.Delta.(type) {
-		case anthropic.ContentBlockDeltaEventDelta:
-			if delta.Text != "" {
-				fullResponseWithTags += delta.Text
-				aps, err := parseActionsInResponse(fullResponseWithTags)
-				if err != nil {
-					return fmt.Errorf("error parsing artifacts in response: %w", err)
-				}
+                switch delta := event.Delta.(type) {
+                case anthropic.ContentBlockDeltaEventDelta:
+                        if delta.Text != "" {
+                                fullResponseWithTags += delta.Text
+                                aps, err := parseActionsInResponse(fullResponseWithTags)
+                                if err != nil {
+                                        return fmt.Errorf("error parsing artifacts in response: %w", err)
+                                }
 
-				for path, action := range aps {
-					// only add if the full struct is there
-					if path != "" && action.Type != "" && action.Action != "" {
-						// if the item is not already in the map, we need to stream it back to the caller
-						if _, ok := actionPlans[path]; !ok {
-							action.Status = types.ActionPlanStatusPending
-							actionPlanWithPath := types.ActionPlanWithPath{
-								Path:       path,
-								ActionPlan: action,
-							}
-							planActionCreatedCh <- actionPlanWithPath
-						}
+                                for path, action := range aps {
+                                        // only add if the full struct is there
+                                        if path != "" && action.Type != "" && action.Action != "" {
+                                                // if the item is not already in the map, we need to stream it back to the caller
+                                                if _, ok := actionPlans[path]; !ok {
+                                                        action.Status = types.ActionPlanStatusPending
+                                                        actionPlanWithPath := types.ActionPlanWithPath{
+                                                                Path:       path,
+                                                                ActionPlan: action,
+                                                        }
+                                                        planActionCreatedCh <- actionPlanWithPath
+                                                }
 
-						actionPlans[path] = action
-					}
-				}
-			}
-		}
-	}
+                                                actionPlans[path] = action
+                                        }
+                                }
+                        }
+                }
+        }
 
-	if stream.Err() != nil {
-		doneCh <- stream.Err()
-	}
+        if stream.Err() != nil {
+                doneCh <- stream.Err()
+        }
 
-	doneCh <- nil
+        doneCh <- nil
 
-	// mark the plan as complete so that the action executors can know when the final step is and mark the plan status as complete
-	if err := workspace.SetPlanIsComplete(ctx, plan.ID, true); err != nil {
-		return fmt.Errorf("failed to mark plan as complete: %w", err)
-	}
+        // mark the plan as complete so that the action executors can know when the final step is and mark the plan status as complete
+        if err := workspace.SetPlanIsComplete(ctx, plan.ID, true); err != nil {
+                return fmt.Errorf("failed to mark plan as complete: %w", err)
+        }
 
-	return nil
+        return nil
 }

--- a/pkg/llm/execute-action.go
+++ b/pkg/llm/execute-action.go
@@ -1,77 +1,77 @@
 package llm
 
 import (
-	"context"
-	"fmt"
+        "context"
+        "fmt"
 
-	anthropic "github.com/anthropics/anthropic-sdk-go"
-	llmtypes "github.com/replicatedhq/chartsmith/pkg/llm/types"
-	workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
+        anthropic "github.com/anthropics/anthropic-sdk-go"
+        llmtypes "github.com/replicatedhq/chartsmith/pkg/llm/types"
+        workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
 )
 
 func ExecuteAction(ctx context.Context, actionPlanWithPath llmtypes.ActionPlanWithPath, plan *workspacetypes.Plan, c *workspacetypes.Chart, contentStreamCh chan string, doneCh chan error) error {
-	client, err := newAnthropicClient(ctx)
-	if err != nil {
-		return err
-	}
+        client, err := newAnthropicClient(ctx)
+        if err != nil {
+                return fmt.Errorf("failed to create Anthropic client: %w", err)
+        }
 
-	messages := []anthropic.MessageParam{
-		anthropic.NewAssistantMessage(anthropic.NewTextBlock(executePlanSystemPrompt)),
-		anthropic.NewUserMessage(anthropic.NewTextBlock(detailedPlanInstructions)),
-	}
+        messages := []anthropic.MessageParam{
+                anthropic.NewAssistantMessage(anthropic.NewTextBlock(executePlanSystemPrompt)),
+                anthropic.NewUserMessage(anthropic.NewTextBlock(detailedPlanInstructions)),
+        }
 
-	detailedPlanMessage := fmt.Sprintf("The Helm chart plan is: %s", plan.Description)
-	messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(detailedPlanMessage)))
+        detailedPlanMessage := fmt.Sprintf("The Helm chart plan is: %s", plan.Description)
+        messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(detailedPlanMessage)))
 
-	if actionPlanWithPath.Action == "create" {
-		createMessage := fmt.Sprintf("Create the file at %s", actionPlanWithPath.Path)
-		messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(createMessage)))
-	} else if actionPlanWithPath.Action == "update" {
-		content := ""
-		for _, file := range c.Files {
-			if file.FilePath == actionPlanWithPath.Path {
-				content = file.Content
-			}
-		}
-		updateMessage := fmt.Sprintf("Update the file at %s. The current content is: %s", actionPlanWithPath.Path, content)
-		messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(updateMessage)))
-	}
+        if actionPlanWithPath.Action == "create" {
+                createMessage := fmt.Sprintf("Create the file at %s", actionPlanWithPath.Path)
+                messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(createMessage)))
+        } else if actionPlanWithPath.Action == "update" {
+                content := ""
+                for _, file := range c.Files {
+                        if file.FilePath == actionPlanWithPath.Path {
+                                content = file.Content
+                        }
+                }
+                updateMessage := fmt.Sprintf("Update the file at %s. The current content is: %s", actionPlanWithPath.Path, content)
+                messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(updateMessage)))
+        }
 
-	stream := client.Messages.NewStreaming(context.TODO(), anthropic.MessageNewParams{
-		Model:     anthropic.F(anthropic.ModelClaude3_5Sonnet20241022),
-		MaxTokens: anthropic.F(int64(8192)),
-		Messages:  anthropic.F(messages),
-	})
+        stream := client.Messages.NewStreaming(context.TODO(), anthropic.MessageNewParams{
+                Model:     anthropic.F(anthropic.ModelClaude3_5Sonnet20241022),
+                MaxTokens: anthropic.F(int64(8192)),
+                Messages:  anthropic.F(messages),
+        })
 
-	fullResponseWithTags := ""
+        fullResponseWithTags := ""
 
-	message := anthropic.Message{}
-	for stream.Next() {
-		event := stream.Current()
-		message.Accumulate(event)
+        message := anthropic.Message{}
+        for stream.Next() {
+                event := stream.Current()
+                message.Accumulate(event)
 
-		switch delta := event.Delta.(type) {
-		case anthropic.ContentBlockDeltaEventDelta:
-			if delta.Text != "" {
-				fullResponseWithTags += delta.Text
-				artifacts, err := parseArtifactsInResponse(fullResponseWithTags)
-				if err != nil {
-					return fmt.Errorf("error parsing artifacts in response: %w", err)
-				}
+                switch delta := event.Delta.(type) {
+                case anthropic.ContentBlockDeltaEventDelta:
+                        if delta.Text != "" {
+                                fullResponseWithTags += delta.Text
+                                artifacts, err := parseArtifactsInResponse(fullResponseWithTags)
+                                if err != nil {
+                                        return fmt.Errorf("error parsing artifacts in response: %w", err)
+                                }
 
-				for _, artifact := range artifacts {
-					if artifact.Path == actionPlanWithPath.Path {
-						contentStreamCh <- artifact.Content
-					}
-				}
-			}
-		}
-	}
+                                for _, artifact := range artifacts {
+                                        if artifact.Path == actionPlanWithPath.Path {
+                                                contentStreamCh <- artifact.Content
+                                        }
+                                }
+                        }
+                }
+        }
 
-	if stream.Err() != nil {
-		doneCh <- stream.Err()
-	}
+        if stream.Err() != nil {
+                doneCh <- stream.Err()
+        }
 
-	doneCh <- nil
-	return nil
+        doneCh <- nil
+        return nil
 }

--- a/pkg/llm/initial-plan.go
+++ b/pkg/llm/initial-plan.go
@@ -1,100 +1,100 @@
 package llm
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
+        "context"
+        "encoding/json"
+        "fmt"
 
-	anthropic "github.com/anthropics/anthropic-sdk-go"
-	"github.com/replicatedhq/chartsmith/pkg/logger"
-	"github.com/replicatedhq/chartsmith/pkg/workspace"
-	workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
+        anthropic "github.com/anthropics/anthropic-sdk-go"
+        "github.com/replicatedhq/chartsmith/pkg/logger"
+        "github.com/replicatedhq/chartsmith/pkg/workspace"
+        workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
 )
 
 func CreateInitialPlan(ctx context.Context, streamCh chan string, doneCh chan error, plan *workspacetypes.Plan) error {
-	logger.Infof("Creating initial plan: %+v\n", plan)
+        logger.Infof("Creating initial plan: %+v\n", plan)
 
-	client, err := newAnthropicClient(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create anthropic client: %w", err)
-	}
+        client, err := newAnthropicClient(ctx)
+        if err != nil {
+                return fmt.Errorf("failed to create anthropic client: %w", err)
+        }
 
-	messages := []anthropic.MessageParam{
-		anthropic.NewAssistantMessage(anthropic.NewTextBlock(initialPlanSystemPrompt)),
-		anthropic.NewAssistantMessage(anthropic.NewTextBlock(initialPlanInstructions)),
-	}
+        messages := []anthropic.MessageParam{
+                anthropic.NewAssistantMessage(anthropic.NewTextBlock(initialPlanSystemPrompt)),
+                anthropic.NewAssistantMessage(anthropic.NewTextBlock(initialPlanInstructions)),
+        }
 
-	// summarize the bootstrap chart and include it as a user message
-	bootsrapChartUserMessage, err := summarizeBootstrapChart(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to summarize bootstrap chart: %w", err)
-	}
-	messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(bootsrapChartUserMessage)))
+        // summarize the bootstrap chart and include it as a user message
+        bootsrapChartUserMessage, err := summarizeBootstrapChart(ctx)
+        if err != nil {
+                return fmt.Errorf("failed to summarize bootstrap chart: %w", err)
+        }
+        messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(bootsrapChartUserMessage)))
 
-	chatMessages := []workspacetypes.Chat{}
-	for _, chatMessageID := range plan.ChatMessageIDs {
-		chatMessage, err := workspace.GetChatMessage(ctx, chatMessageID)
-		if err != nil {
-			return err
-		}
-		chatMessages = append(chatMessages, *chatMessage)
-	}
+        chatMessages := []workspacetypes.Chat{}
+        for _, chatMessageID := range plan.ChatMessageIDs {
+                chatMessage, err := workspace.GetChatMessage(ctx, chatMessageID)
+                if err != nil {
+                        return fmt.Errorf("failed to get chat message %s: %w", chatMessageID, err)
+                }
+                chatMessages = append(chatMessages, *chatMessage)
+        }
 
-	for _, chatMessage := range chatMessages {
-		messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(chatMessage.Prompt)))
-		if chatMessage.Response != "" {
-			messages = append(messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock(chatMessage.Response)))
-		}
-	}
+        for _, chatMessage := range chatMessages {
+                messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(chatMessage.Prompt)))
+                if chatMessage.Response != "" {
+                        messages = append(messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock(chatMessage.Response)))
+                }
+        }
 
-	initialUserMessage := "Describe the plan only (do not write code) to create a helm chart based on the previous discussion. "
+        initialUserMessage := "Describe the plan only (do not write code) to create a helm chart based on the previous discussion. "
 
-	messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(initialUserMessage)))
+        messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(initialUserMessage)))
 
-	stream := client.Messages.NewStreaming(context.TODO(), anthropic.MessageNewParams{
-		Model:     anthropic.F(anthropic.ModelClaude3_5Sonnet20241022),
-		MaxTokens: anthropic.F(int64(8192)),
-		Messages:  anthropic.F(messages),
-	})
+        stream := client.Messages.NewStreaming(context.TODO(), anthropic.MessageNewParams{
+                Model:     anthropic.F(anthropic.ModelClaude3_5Sonnet20241022),
+                MaxTokens: anthropic.F(int64(8192)),
+                Messages:  anthropic.F(messages),
+        })
 
-	message := anthropic.Message{}
-	for stream.Next() {
-		event := stream.Current()
-		message.Accumulate(event)
+        message := anthropic.Message{}
+        for stream.Next() {
+                event := stream.Current()
+                message.Accumulate(event)
 
-		switch delta := event.Delta.(type) {
-		case anthropic.ContentBlockDeltaEventDelta:
-			if delta.Text != "" {
-				streamCh <- delta.Text
-			}
-		}
-	}
+                switch delta := event.Delta.(type) {
+                case anthropic.ContentBlockDeltaEventDelta:
+                        if delta.Text != "" {
+                                streamCh <- delta.Text
+                        }
+                }
+        }
 
-	if stream.Err() != nil {
-		doneCh <- stream.Err()
-	}
+        if stream.Err() != nil {
+                doneCh <- stream.Err()
+        }
 
-	doneCh <- nil
-	return nil
+        doneCh <- nil
+        return nil
 }
 
 func summarizeBootstrapChart(ctx context.Context) (string, error) {
-	bootstrapWorkspace, err := workspace.GetBootstrapWorkspace(ctx)
-	if err != nil {
-		return "", fmt.Errorf("failed to get bootstrap workspace: %w", err)
-	}
+        bootstrapWorkspace, err := workspace.GetBootstrapWorkspace(ctx)
+        if err != nil {
+                return "", fmt.Errorf("failed to get bootstrap workspace: %w", err)
+        }
 
-	filesWithContent := map[string]string{}
-	for _, chart := range bootstrapWorkspace.Charts {
-		for _, file := range chart.Files {
-			filesWithContent[file.FilePath] = file.Content
-		}
-	}
+        filesWithContent := map[string]string{}
+        for _, chart := range bootstrapWorkspace.Charts {
+                for _, file := range chart.Files {
+                        filesWithContent[file.FilePath] = file.Content
+                }
+        }
 
-	encoded, err := json.Marshal(filesWithContent)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal files with content: %w", err)
-	}
+        encoded, err := json.Marshal(filesWithContent)
+        if err != nil {
+                return "", fmt.Errorf("failed to marshal files with content: %w", err)
+        }
 
-	return fmt.Sprintf("The chart we are basing our work on looks like this: \n %s", string(encoded)), nil
+        return fmt.Sprintf("The chart we are basing our work on looks like this: \n %s", string(encoded)), nil
 }

--- a/pkg/llm/plan.go
+++ b/pkg/llm/plan.go
@@ -1,93 +1,93 @@
 package llm
 
 import (
-	"context"
-	"encoding/json"
-	"fmt"
+        "context"
+        "encoding/json"
+        "fmt"
 
-	anthropic "github.com/anthropics/anthropic-sdk-go"
-	"github.com/replicatedhq/chartsmith/pkg/workspace"
-	workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
+        anthropic "github.com/anthropics/anthropic-sdk-go"
+        "github.com/replicatedhq/chartsmith/pkg/workspace"
+        workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
 )
 
 func CreatePlan(ctx context.Context, streamCh chan string, doneCh chan error, w *workspacetypes.Workspace, plan *workspacetypes.Plan) error {
-	client, err := newAnthropicClient(ctx)
-	if err != nil {
-		return fmt.Errorf("failed to create anthropic client: %w", err)
-	}
+        client, err := newAnthropicClient(ctx)
+        if err != nil {
+                return fmt.Errorf("failed to create anthropic client: %w", err)
+        }
 
-	messages := []anthropic.MessageParam{
-		anthropic.NewAssistantMessage(anthropic.NewTextBlock(initialPlanSystemPrompt)),
-		anthropic.NewAssistantMessage(anthropic.NewTextBlock(initialPlanInstructions)),
-	}
+        messages := []anthropic.MessageParam{
+                anthropic.NewAssistantMessage(anthropic.NewTextBlock(initialPlanSystemPrompt)),
+                anthropic.NewAssistantMessage(anthropic.NewTextBlock(initialPlanInstructions)),
+        }
 
-	var c *workspacetypes.Chart
-	c = &w.Charts[0]
+        var c *workspacetypes.Chart
+        c = &w.Charts[0]
 
-	currentChartUserMessage, err := summarizeChart(ctx, c)
-	if err != nil {
-		return fmt.Errorf("failed to summarize chart: %w", err)
-	}
-	messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(currentChartUserMessage)))
+        currentChartUserMessage, err := summarizeChart(ctx, c)
+        if err != nil {
+                return fmt.Errorf("failed to summarize chart: %w", err)
+        }
+        messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(currentChartUserMessage)))
 
-	chatMessages := []workspacetypes.Chat{}
-	for _, chatMessageID := range plan.ChatMessageIDs {
-		chatMessage, err := workspace.GetChatMessage(ctx, chatMessageID)
-		if err != nil {
-			return err
-		}
-		chatMessages = append(chatMessages, *chatMessage)
-	}
+        chatMessages := []workspacetypes.Chat{}
+        for _, chatMessageID := range plan.ChatMessageIDs {
+                chatMessage, err := workspace.GetChatMessage(ctx, chatMessageID)
+                if err != nil {
+                        return fmt.Errorf("failed to get chat message %s: %w", chatMessageID, err)
+                }
+                chatMessages = append(chatMessages, *chatMessage)
+        }
 
-	for _, chatMessage := range chatMessages {
-		messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(chatMessage.Prompt)))
-		if chatMessage.Response != "" {
-			messages = append(messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock(chatMessage.Response)))
-		}
-	}
+        for _, chatMessage := range chatMessages {
+                messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(chatMessage.Prompt)))
+                if chatMessage.Response != "" {
+                        messages = append(messages, anthropic.NewAssistantMessage(anthropic.NewTextBlock(chatMessage.Response)))
+                }
+        }
 
-	initialUserMessage := "Describe the plan only (do not write code) to create a helm chart based on the previous discussion. "
+        initialUserMessage := "Describe the plan only (do not write code) to create a helm chart based on the previous discussion. "
 
-	messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(initialUserMessage)))
+        messages = append(messages, anthropic.NewUserMessage(anthropic.NewTextBlock(initialUserMessage)))
 
-	stream := client.Messages.NewStreaming(context.TODO(), anthropic.MessageNewParams{
-		Model:     anthropic.F(anthropic.ModelClaude3_5Sonnet20241022),
-		MaxTokens: anthropic.F(int64(8192)),
-		Messages:  anthropic.F(messages),
-	})
+        stream := client.Messages.NewStreaming(context.TODO(), anthropic.MessageNewParams{
+                Model:     anthropic.F(anthropic.ModelClaude3_5Sonnet20241022),
+                MaxTokens: anthropic.F(int64(8192)),
+                Messages:  anthropic.F(messages),
+        })
 
-	message := anthropic.Message{}
-	for stream.Next() {
-		event := stream.Current()
-		message.Accumulate(event)
+        message := anthropic.Message{}
+        for stream.Next() {
+                event := stream.Current()
+                message.Accumulate(event)
 
-		switch delta := event.Delta.(type) {
-		case anthropic.ContentBlockDeltaEventDelta:
-			if delta.Text != "" {
-				streamCh <- delta.Text
-			}
-		}
-	}
+                switch delta := event.Delta.(type) {
+                case anthropic.ContentBlockDeltaEventDelta:
+                        if delta.Text != "" {
+                                streamCh <- delta.Text
+                        }
+                }
+        }
 
-	if stream.Err() != nil {
-		doneCh <- stream.Err()
-	}
+        if stream.Err() != nil {
+                doneCh <- stream.Err()
+        }
 
-	doneCh <- nil
-	return nil
+        doneCh <- nil
+        return nil
 }
 
 func summarizeChart(ctx context.Context, c *workspacetypes.Chart) (string, error) {
-	filesWithContent := map[string]string{}
+        filesWithContent := map[string]string{}
 
-	for _, file := range c.Files {
-		filesWithContent[file.FilePath] = file.Content
-	}
+        for _, file := range c.Files {
+                filesWithContent[file.FilePath] = file.Content
+        }
 
-	encoded, err := json.Marshal(filesWithContent)
-	if err != nil {
-		return "", fmt.Errorf("failed to marshal files with content: %w", err)
-	}
+        encoded, err := json.Marshal(filesWithContent)
+        if err != nil {
+                return "", fmt.Errorf("failed to marshal files with content: %w", err)
+        }
 
-	return fmt.Sprintf("The chart we are basing our work on looks like this: \n %s", string(encoded)), nil
+        return fmt.Sprintf("The chart we are basing our work on looks like this: \n %s", string(encoded)), nil
 }

--- a/pkg/realtime/centrifugo.go
+++ b/pkg/realtime/centrifugo.go
@@ -1,79 +1,79 @@
 package realtime
 
 import (
-	"bytes"
-	"context"
-	"encoding/json"
-	"fmt"
-	"log"
-	"net/http"
+        "bytes"
+        "context"
+        "encoding/json"
+        "fmt"
+        "log"
+        "net/http"
 
-	"github.com/replicatedhq/chartsmith/pkg/logger"
-	"github.com/replicatedhq/chartsmith/pkg/realtime/types"
+        "github.com/replicatedhq/chartsmith/pkg/logger"
+        "github.com/replicatedhq/chartsmith/pkg/realtime/types"
 )
 
 var (
-	centrifugoConfig *types.Config
+        centrifugoConfig *types.Config
 )
 
 func Init(c *types.Config) {
-	centrifugoConfig = c
+        centrifugoConfig = c
 }
 
 func SendEvent(ctx context.Context, r types.Recipient, e types.Event) error {
-	messageData, err := e.GetMessageData()
-	if err != nil {
-		return err
-	}
+        messageData, err := e.GetMessageData()
+        if err != nil {
+                return fmt.Errorf("failed to get message data: %w", err)
+        }
 
-	for _, userID := range r.GetUserIDs() {
-		userChannelName := fmt.Sprintf("%s#%s", e.GetChannelName(), userID)
-		if err := sendMessage(userChannelName, messageData); err != nil {
-			logger.Errorf("Failed to send message to user %s: %v", userID, err)
-		}
-	}
+        for _, userID := range r.GetUserIDs() {
+                userChannelName := fmt.Sprintf("%s#%s", e.GetChannelName(), userID)
+                if err := sendMessage(userChannelName, messageData); err != nil {
+                        logger.Errorf("Failed to send message to user %s: %v", userID, err)
+                }
+        }
 
-	return nil
+        return nil
 }
 
 func sendMessage(channelName string, data map[string]interface{}) error {
-	if centrifugoConfig == nil {
-		panic("Centrifugo config not initialized")
-	}
+        if centrifugoConfig == nil {
+                panic("Centrifugo config not initialized")
+        }
 
-	url := centrifugoConfig.Address
-	apiKey := centrifugoConfig.APIKey
+        url := centrifugoConfig.Address
+        apiKey := centrifugoConfig.APIKey
 
-	requestBody := map[string]interface{}{
-		"method": "publish",
-		"params": map[string]interface{}{
-			"channel": channelName,
-			"data":    data,
-		},
-	}
+        requestBody := map[string]interface{}{
+                "method": "publish",
+                "params": map[string]interface{}{
+                        "channel": channelName,
+                        "data":    data,
+                },
+        }
 
-	jsonData, err := json.Marshal(requestBody)
-	if err != nil {
-		log.Fatalf("Error encoding JSON: %v", err)
-	}
+        jsonData, err := json.Marshal(requestBody)
+        if err != nil {
+                log.Fatalf("Error encoding JSON: %v", err)
+        }
 
-	req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
-	if err != nil {
-		log.Fatalf("Error creating request: %v", err)
-	}
+        req, err := http.NewRequest("POST", url, bytes.NewBuffer(jsonData))
+        if err != nil {
+                log.Fatalf("Error creating request: %v", err)
+        }
 
-	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("Authorization", "apikey "+apiKey)
+        req.Header.Set("Content-Type", "application/json")
+        req.Header.Set("Authorization", "apikey "+apiKey)
 
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		log.Fatalf("Error sending request to Centrifugo server: %v", err)
-	}
-	defer resp.Body.Close()
+        resp, err := http.DefaultClient.Do(req)
+        if err != nil {
+                log.Fatalf("Error sending request to Centrifugo server: %v", err)
+        }
+        defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusOK {
-		log.Fatalf("Failed to send message, status code: %d", resp.StatusCode)
-	}
+        if resp.StatusCode != http.StatusOK {
+                log.Fatalf("Failed to send message, status code: %d", resp.StatusCode)
+        }
 
-	return nil
+        return nil
 }

--- a/pkg/testhelpers/pg.go
+++ b/pkg/testhelpers/pg.go
@@ -1,114 +1,114 @@
 package testhelpers
 
 import (
-	"bytes"
-	"context"
-	"os"
-	"path/filepath"
-	"time"
+        "bytes"
+        "context"
+        "os"
+        "path/filepath"
+        "time"
 
-	"github.com/testcontainers/testcontainers-go"
-	"github.com/testcontainers/testcontainers-go/modules/postgres"
-	"github.com/testcontainers/testcontainers-go/wait"
+        "github.com/testcontainers/testcontainers-go"
+        "github.com/testcontainers/testcontainers-go/modules/postgres"
+        "github.com/testcontainers/testcontainers-go/wait"
 )
 
 type PostgresContainer struct {
-	*postgres.PostgresContainer
-	ConnectionString string
-	Logs             *bytes.Buffer
+        *postgres.PostgresContainer
+        ConnectionString string
+        Logs             *bytes.Buffer
 }
 
 func CreatePostgresContainer(ctx context.Context) (*PostgresContainer, error) {
-	initDatafiles := []string{
-		"testdata/01-extensions.sql",
-		"testdata/02-fixtures.sql",
-	}
+        initDatafiles := []string{
+                "testdata/01-extensions.sql",
+                "testdata/02-fixtures.sql",
+        }
 
-	// for some reason, i need to put the testdata from the data into the fixtures file
-	// or testcontainers acts like something is wrong. i don't know testcontainers
-	// well enough, but also getting real tired or fighting it
+        // for some reason, i need to put the testdata from the data into the fixtures file
+        // or testcontainers acts like something is wrong. i don't know testcontainers
+        // well enough, but also getting real tired or fighting it
 
-	if err := filepath.Walk("testdata/gen-data", func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return nil
-		}
-		if filepath.Ext(path) == ".sql" {
-			// make sure it's not already there
-			initDatafiles = append(initDatafiles, path)
-		}
-		return nil
-	}); err != nil {
-		return nil, err
-	}
+        if err := filepath.Walk("testdata/gen-data", func(path string, info os.FileInfo, err error) error {
+                if err != nil {
+                        return fmt.Errorf("failed to walk gen-data directory: %w", err)
+                }
+                if info.IsDir() {
+                        return nil
+                }
+                if filepath.Ext(path) == ".sql" {
+                        // make sure it's not already there
+                        initDatafiles = append(initDatafiles, path)
+                }
+                return nil
+        }); err != nil {
+                return nil, fmt.Errorf("failed to walk gen-data directory: %w", err)
+        }
 
-	if err := filepath.Walk("testdata/static-data", func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return err
-		}
-		if info.IsDir() {
-			return nil
-		}
-		if filepath.Ext(path) == ".sql" {
-			// make sure it's not already there
-			initDatafiles = append(initDatafiles, path)
-		}
-		return nil
-	}); err != nil {
-		return nil, err
-	}
+        if err := filepath.Walk("testdata/static-data", func(path string, info os.FileInfo, err error) error {
+                if err != nil {
+                        return fmt.Errorf("failed to walk static-data directory: %w", err)
+                }
+                if info.IsDir() {
+                        return nil
+                }
+                if filepath.Ext(path) == ".sql" {
+                        // make sure it's not already there
+                        initDatafiles = append(initDatafiles, path)
+                }
+                return nil
+        }); err != nil {
+                return nil, fmt.Errorf("failed to walk static-data directory: %w", err)
+        }
 
-	mergedFilename := filepath.Join("testdata", "init-scripts-merged.sql")
-	if _, err := os.Stat(mergedFilename); err == nil {
-		if err := os.Remove(mergedFilename); err != nil {
-			return nil, err
-		}
-	}
+        mergedFilename := filepath.Join("testdata", "init-scripts-merged.sql")
+        if _, err := os.Stat(mergedFilename); err == nil {
+                if err := os.Remove(mergedFilename); err != nil {
+                        return nil, fmt.Errorf("failed to remove existing merged file: %w", err)
+                }
+        }
 
-	mergedFile, err := os.Create(mergedFilename)
-	if err != nil {
-		return nil, err
-	}
-	defer mergedFile.Close()
+        mergedFile, err := os.Create(mergedFilename)
+        if err != nil {
+                return nil, fmt.Errorf("failed to create merged file: %w", err)
+        }
+        defer mergedFile.Close()
 
-	for _, initDatafile := range initDatafiles {
-		b, err := os.ReadFile(initDatafile)
-		if err != nil {
-			return nil, err
-		}
-		if _, err := mergedFile.Write(b); err != nil {
-			return nil, err
-		}
-		if _, err := mergedFile.WriteString("\n"); err != nil {
-			return nil, err
-		}
-	}
-	mergedFile.Close()
+        for _, initDatafile := range initDatafiles {
+                b, err := os.ReadFile(initDatafile)
+                if err != nil {
+                        return nil, fmt.Errorf("failed to read init data file %s: %w", initDatafile, err)
+                }
+                if _, err := mergedFile.Write(b); err != nil {
+                        return nil, fmt.Errorf("failed to write to merged file: %w", err)
+                }
+                if _, err := mergedFile.WriteString("\n"); err != nil {
+                        return nil, fmt.Errorf("failed to write newline to merged file: %w", err)
+                }
+        }
+        mergedFile.Close()
 
-	pgContainer, err := postgres.RunContainer(ctx,
-		testcontainers.WithImage("pgvector/pgvector:pg16"),
-		postgres.WithInitScripts(mergedFile.Name()),
-		postgres.WithDatabase("test-db"),
-		postgres.WithUsername("postgres"),
-		postgres.WithPassword("postgres"),
-		testcontainers.WithWaitStrategy(
-			wait.
-				ForLog("database system is ready to accept connections").
-				WithOccurrence(2).
-				WithStartupTimeout(10*time.Second)),
-	)
-	if err != nil {
-		return nil, err
-	}
-	connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
-	if err != nil {
-		return nil, err
-	}
+        pgContainer, err := postgres.RunContainer(ctx,
+                testcontainers.WithImage("pgvector/pgvector:pg16"),
+                postgres.WithInitScripts(mergedFile.Name()),
+                postgres.WithDatabase("test-db"),
+                postgres.WithUsername("postgres"),
+                postgres.WithPassword("postgres"),
+                testcontainers.WithWaitStrategy(
+                        wait.
+                                ForLog("database system is ready to accept connections").
+                                WithOccurrence(2).
+                                WithStartupTimeout(10*time.Second)),
+        )
+        if err != nil {
+                return nil, fmt.Errorf("failed to run Postgres container: %w", err)
+        }
+        connStr, err := pgContainer.ConnectionString(ctx, "sslmode=disable")
+        if err != nil {
+                return nil, fmt.Errorf("failed to get connection string: %w", err)
+        }
 
-	return &PostgresContainer{
-		PostgresContainer: pgContainer,
-		ConnectionString:  connStr,
-	}, nil
+        return &PostgresContainer{
+                PostgresContainer: pgContainer,
+                ConnectionString:  connStr,
+        }, nil
 }

--- a/pkg/workspace/file.go
+++ b/pkg/workspace/file.go
@@ -1,51 +1,51 @@
 package workspace
 
 import (
-	"context"
-	"database/sql"
+        "context"
+        "database/sql"
 
-	"github.com/replicatedhq/chartsmith/pkg/persistence"
-	"github.com/replicatedhq/chartsmith/pkg/workspace/types"
+        "github.com/replicatedhq/chartsmith/pkg/persistence"
+        "github.com/replicatedhq/chartsmith/pkg/workspace/types"
 )
 
 func GetFile(ctx context.Context, fileID string, revisionNumber int) (*types.File, error) {
-	conn := persistence.MustGetPooledPostgresSession()
-	defer conn.Release()
+        conn := persistence.MustGetPooledPostgresSession()
+        defer conn.Release()
 
-	query := `SELECT
-		id,
-		revision_number,
-		chart_id,
-		workspace_id,
-		file_path,
-		content,
-		summary
-	FROM
-		workspace_file
-	WHERE
-		id = $1 AND revision_number = $2`
+        query := `SELECT
+                id,
+                revision_number,
+                chart_id,
+                workspace_id,
+                file_path,
+                content,
+                summary
+        FROM
+                workspace_file
+        WHERE
+                id = $1 AND revision_number = $2`
 
-	row := conn.QueryRow(ctx, query, fileID, revisionNumber)
-	var file types.File
-	var summary sql.NullString
-	err := row.Scan(&file.ID, &file.RevisionNumber, &file.ChartID, &file.WorkspaceID, &file.FilePath, &file.Content, &summary)
-	if err != nil {
-		return nil, err
-	}
-	file.Summary = summary.String
+        row := conn.QueryRow(ctx, query, fileID, revisionNumber)
+        var file types.File
+        var summary sql.NullString
+        err := row.Scan(&file.ID, &file.RevisionNumber, &file.ChartID, &file.WorkspaceID, &file.FilePath, &file.Content, &summary)
+        if err != nil {
+                return nil, fmt.Errorf("failed to scan file row: %w", err)
+        }
+        file.Summary = summary.String
 
-	return &file, nil
+        return &file, nil
 }
 
 func SetFileSummaryAndEmbeddings(ctx context.Context, fileID string, revisionNumber int, summary string, embeddings string) error {
-	conn := persistence.MustGetPooledPostgresSession()
-	defer conn.Release()
+        conn := persistence.MustGetPooledPostgresSession()
+        defer conn.Release()
 
-	query := `UPDATE workspace_file SET summary = $1, embeddings = $2 WHERE id = $3 AND revision_number = $4`
-	_, err := conn.Exec(ctx, query, summary, embeddings, fileID, revisionNumber)
-	if err != nil {
-		return err
-	}
+        query := `UPDATE workspace_file SET summary = $1, embeddings = $2 WHERE id = $3 AND revision_number = $4`
+        _, err := conn.Exec(ctx, query, summary, embeddings, fileID, revisionNumber)
+        if err != nil {
+                return fmt.Errorf("failed to update file summary and embeddings: %w", err)
+        }
 
-	return nil
+        return nil
 }


### PR DESCRIPTION
This change improves error handling by:
- Adding descriptive context to all error returns
- Using fmt.Errorf with %w to properly wrap errors
- Making error messages more consistent and descriptive
- Preserving error chain for better debugging

Changes made:
- Found all instances of bare `return err` in Go files
- Wrapped them with descriptive context using fmt.Errorf
- Used %w to maintain error chain for better debugging
- Made error messages consistent across the codebase