### PR TITLE
Make releases for linux/amd64

### DIFF
--- a/dagger/worker.go
+++ b/dagger/worker.go
@@ -71,6 +71,8 @@ func buildEnvWorker(source *dagger.Directory) *dagger.Container {
 		WithDirectory("/go/src/github.com/replicatedhq/chartsmith", source).
 		WithWorkdir("/go/src/github.com/replicatedhq/chartsmith").
 		WithMountedCache("/go/pkg/mod", cache).
+		WithEnvVariable("GOOS", "linux").
+		WithEnvVariable("GOARCH", "amd64").
 		WithEnvVariable("GOMODCACHE", "/go/pkg/mod").
 		WithMountedCache("/go/build-cache", cache).
 		WithEnvVariable("GOCACHE", "/go/build-cache").


### PR DESCRIPTION
Logs show exec format, but the pod is running on an amd64 node.
 
```
$ kubectl -n chartsmith logs -p chartsmith-worker-645d857df8-vb6nx  -c bootstrap
exec /go/src/github.com/replicatedhq/chartsmith/bin/chartsmith-worker: exec format error
```