### PR TITLE
Fix waitlist Return to Home button functionality

### DIFF
--- a/chartsmith-app/app/page.tsx
+++ b/chartsmith-app/app/page.tsx
@@ -20,9 +20,12 @@ export default function HomePage() {
   const { isWaitlisted, isAuthLoading } = useAuth();
   const router = useRouter();
 
-  // Handle waitlist redirect
+  // Handle waitlist redirect - only for initial page load, not for explicit navigation
   useEffect(() => {
-    if (!isAuthLoading && isWaitlisted) {
+    // Check if this was a direct page load rather than navigation from waitlist page
+    const isDirectPageLoad = !document.referrer.includes('/waitlist');
+    
+    if (!isAuthLoading && isWaitlisted && isDirectPageLoad) {
       router.replace('/waitlist');
     }
   }, [isWaitlisted, isAuthLoading, router]);

--- a/chartsmith-app/app/waitlist/page.tsx
+++ b/chartsmith-app/app/waitlist/page.tsx
@@ -67,13 +67,14 @@ export default function WaitlistPage() {
         </div>
 
         <div className="mt-8">
-          <Button
-            variant="default"
-            onClick={() => router.push("/")}
-            className="bg-primary hover:bg-primary/90 text-white"
-          >
-            Return to Home
-          </Button>
+          <a href="/" className="inline-block">
+            <Button
+              variant="default"
+              className="bg-primary hover:bg-primary/90 text-white"
+            >
+              Return to Home
+            </Button>
+          </a>
         </div>
       </Card>
     </div>


### PR DESCRIPTION
## Summary
  - Fixed the Return to Home button on the waitlist page that wasn't working properly
  - Changed button to use direct HTML link instead of Next.js router navigation
  - Added smarter redirect logic on homepage to prevent redirect loops
  - Used document.referrer to detect navigation source and allow waitlisted users to view the homepage when explicitly clicking the button

  ## Test plan
  - Login as a waitlisted user
  - Verify you see the waitlist page
  - Click "Return to Home" button
  - Confirm you can successfully view the homepage

🤖 Generated with [Claude Code](https://claude.ai/code)