### PR TITLE
Proposal: Webview for Diffs

### DIFF
--- a/chartsmith-extension/package.json
+++ b/chartsmith-extension/package.json
@@ -80,6 +80,10 @@
         "title": "ChartSmith: Show File Diff"
       },
       {
+        "command": "chartsmith.showCustomFileDiff",
+        "title": "ChartSmith: Show Native File Diff (Preview)"
+      },
+      {
         "command": "chartsmith.refreshDiffButtons",
         "title": "ChartSmith: Refresh Diff Buttons Visibility"
       }

--- a/chartsmith-extension/src/extension.ts
+++ b/chartsmith-extension/src/extension.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
 import { activate as activateLifecycle, deactivate as deactivateLifecycle } from './modules/lifecycle';
 import { showFileDiff, saveDiffState, restoreDiffState, setExtensionContext, updateDiffButtonsVisibility, forceRefreshDiffButtons } from './modules/render';
+import customDiffModule from './modules/customDiff';
 import * as path from 'path';
 import * as fs from 'fs';
 
@@ -68,6 +69,9 @@ export function activate(context: vscode.ExtensionContext) {
       await showFileDiff(filePath, newContent, 'Custom Diff');
     })
   );
+  
+  // Register custom diff commands (Phase 1: Monaco-based webview diff)
+  customDiffModule.registerCustomDiffCommands(context);
   
   // Listen for window state changes to save diff state
   context.subscriptions.push(

--- a/chartsmith-extension/src/modules/customDiff/diffWebview.ts
+++ b/chartsmith-extension/src/modules/customDiff/diffWebview.ts
@@ -1,0 +1,408 @@
+/**
+ * Creates the HTML content for the Chartsmith diff webview
+ */
+
+import * as vscode from 'vscode';
+
+// Define the interface locally to avoid circular imports
+export interface DiffFile {
+  id: string;
+  path: string;
+  name: string;
+  status: 'added' | 'modified' | 'removed';
+  changes: number;
+}
+
+/**
+ * Generates the HTML content for the diff webview
+ * @param webview The webview to create content for
+ * @param diffId The unique ID for this diff session
+ * @returns The HTML content for the webview
+ */
+export function getDiffWebviewContent(webview: vscode.Webview, diffId: string): string {
+  // Sample chart content with version change
+  const originalContent = 
+`apiVersion: v2
+name: my-helm-chart
+description: A Helm chart for Kubernetes
+type: application
+version: 0.6.5
+appVersion: "1.16.0"
+dependencies:
+  - name: common
+    version: 1.0.0
+    repository: https://charts.bitnami.com/bitnami`;
+
+  const modifiedContent = 
+`apiVersion: v2
+name: my-helm-chart
+description: A Helm chart for Kubernetes
+type: application
+version: 0.7.0
+appVersion: "1.16.0"
+dependencies:
+  - name: common
+    version: 1.0.0
+    repository: https://charts.bitnami.com/bitnami`;
+
+  // Create a basic HTML diff view without relying on Monaco
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Chartsmith Diff</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+      background-color: #1e1e1e;
+      color: #cccccc;
+    }
+    
+    .container {
+      display: flex;
+      flex-direction: column;
+      height: 100vh;
+    }
+    
+    /* Header */
+    .header {
+      background-color: #252526;
+      color: #cccccc;
+      padding: 10px 16px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      border-bottom: 1px solid #3c3c3c;
+    }
+    
+    .logo {
+      display: flex;
+      align-items: center;
+      font-weight: 600;
+      font-size: 16px;
+    }
+    
+    .logo-icon {
+      width: 20px;
+      height: 20px;
+      margin-right: 8px;
+    }
+    
+    .workspace-info {
+      font-size: 14px;
+    }
+    
+    /* Main Content Layout */
+    .content-container {
+      display: flex;
+      flex: 1;
+      overflow: hidden;
+    }
+    
+    /* File Navigator */
+    .file-navigator {
+      width: 220px;
+      background-color: #252526;
+      border-right: 1px solid #3c3c3c;
+      overflow: auto;
+      color: #cccccc;
+      font-size: 13px;
+    }
+    
+    .nav-header {
+      padding: 10px 12px;
+      font-size: 11px;
+      text-transform: uppercase;
+      color: #8c8c8c;
+      font-weight: 600;
+      letter-spacing: 0.5px;
+    }
+    
+    .file-item {
+      padding: 6px 12px;
+      display: flex;
+      align-items: center;
+      cursor: pointer;
+      user-select: none;
+      border-left: 2px solid transparent;
+    }
+    
+    .file-item.active {
+      background-color: #37373d;
+      border-left: 2px solid #003399;
+    }
+    
+    .file-item:hover:not(.active) {
+      background-color: #2a2d2e;
+    }
+    
+    .file-icon {
+      width: 16px;
+      height: 16px;
+      margin-right: 8px;
+      opacity: 0.8;
+    }
+    
+    /* Main Content */
+    .main-content {
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      overflow: hidden;
+    }
+    
+    /* Toolbar */
+    .toolbar {
+      background-color: #1e1e1e;
+      border-bottom: 1px solid #333;
+      padding: 8px 16px;
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+    }
+    
+    .file-info {
+      font-size: 14px;
+      display: flex;
+      align-items: center;
+    }
+    
+    .file-path {
+      margin-left: 8px;
+      opacity: 0.7;
+    }
+    
+    /* Actions section for buttons */
+    .actions {
+      display: flex;
+      gap: 8px;
+    }
+    
+    .btn {
+      padding: 6px 12px;
+      border-radius: 4px;
+      border: none;
+      cursor: pointer;
+      font-size: 13px;
+      font-weight: 500;
+      display: flex;
+      align-items: center;
+      gap: 6px;
+    }
+    
+    .btn-accept {
+      background-color: #22c55e;
+      color: white;
+    }
+    
+    .btn-accept:hover {
+      background-color: #16a34a;
+    }
+    
+    .btn-reject {
+      background-color: #ef4444;
+      color: white;
+    }
+    
+    .btn-reject:hover {
+      background-color: #dc2626;
+    }
+    
+    /* Diff View */
+    .diff-container {
+      flex: 1;
+      overflow: auto;
+      font-family: monospace;
+      font-size: 13px;
+      line-height: 1.5;
+      padding: 16px 0;
+    }
+    
+    .diff-line {
+      display: flex;
+      white-space: pre;
+    }
+    
+    .line-number {
+      width: 40px;
+      text-align: right;
+      padding-right: 16px;
+      color: #888;
+      user-select: none;
+    }
+    
+    .line-content {
+      flex: 1;
+    }
+    
+    .line-removed {
+      background-color: rgba(255, 0, 0, 0.2);
+    }
+    
+    .line-added {
+      background-color: rgba(0, 255, 0, 0.1);
+    }
+  </style>
+</head>
+<body>
+  <div class="container">
+    <!-- Header -->
+    <div class="header">
+      <div class="logo">
+        <svg class="logo-icon" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+          <path d="M21 16V8a2 2 0 0 0-1-1.73l-7-4a2 2 0 0 0-2 0l-7 4A2 2 0 0 0 3 8v8a2 2 0 0 0 1 1.73l7 4a2 2 0 0 0 2 0l7-4A2 2 0 0 0 21 16z"></path>
+        </svg>
+        Chartsmith Diff Viewer
+      </div>
+      <div class="workspace-info">My Chartsmith Workspace — platform-examples</div>
+    </div>
+    
+    <!-- Main Content with File Navigator -->
+    <div class="content-container">
+      <!-- File Navigator -->
+      <div class="file-navigator">
+        <div class="nav-header">Files Changed</div>
+        <div class="file-item active">
+          <svg class="file-icon" viewBox="0 0 16 16" fill="none" stroke="currentColor" stroke-width="1.5">
+            <path d="M13 14H3c-.6 0-1-.4-1-1V3c0-.6.4-1 1-1h5l2 2h3c.6 0 1 .4 1 1v8c0 .6-.4 1-1 1z"/>
+          </svg>
+          Chart.yaml
+        </div>
+      </div>
+      
+      <!-- Main Content -->
+      <div class="main-content">
+        <!-- Toolbar -->
+        <div class="toolbar">
+          <div class="file-info">
+            <span>Chart.yaml</span>
+            <span class="file-path">/Chart.yaml</span>
+          </div>
+          <div class="actions">
+            <button class="btn btn-accept" id="accept-btn">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <polyline points="20 6 9 17 4 12"></polyline>
+              </svg>
+              Accept
+            </button>
+            <button class="btn btn-reject" id="reject-btn">
+              <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <line x1="18" y1="6" x2="6" y2="18"></line>
+                <line x1="6" y1="6" x2="18" y2="18"></line>
+              </svg>
+              Reject
+            </button>
+          </div>
+        </div>
+        
+        <!-- Diff View -->
+        <div class="diff-container" id="diff-container">
+          <!-- Line 1 -->
+          <div class="diff-line">
+            <div class="line-number">1</div>
+            <div class="line-content">apiVersion: v2</div>
+          </div>
+          <!-- Line 2 -->
+          <div class="diff-line">
+            <div class="line-number">2</div>
+            <div class="line-content">name: my-helm-chart</div>
+          </div>
+          <!-- Line 3 -->
+          <div class="diff-line">
+            <div class="line-number">3</div>
+            <div class="line-content">description: A Helm chart for Kubernetes</div>
+          </div>
+          <!-- Line 4 -->
+          <div class="diff-line">
+            <div class="line-number">4</div>
+            <div class="line-content">type: application</div>
+          </div>
+          <!-- Line 5 (removed) -->
+          <div class="diff-line line-removed">
+            <div class="line-number">5</div>
+            <div class="line-content">version: 0.6.5</div>
+          </div>
+          <!-- Line 6 (added) -->
+          <div class="diff-line line-added">
+            <div class="line-number">6</div>
+            <div class="line-content">version: 0.7.0</div>
+          </div>
+          <!-- Line 7 -->
+          <div class="diff-line">
+            <div class="line-number">7</div>
+            <div class="line-content">appVersion: "1.16.0"</div>
+          </div>
+          <!-- Line 8 -->
+          <div class="diff-line">
+            <div class="line-number">8</div>
+            <div class="line-content">dependencies:</div>
+          </div>
+          <!-- Line 9 -->
+          <div class="diff-line">
+            <div class="line-number">9</div>
+            <div class="line-content">  - name: common</div>
+          </div>
+          <!-- Line 10 -->
+          <div class="diff-line">
+            <div class="line-number">10</div>
+            <div class="line-content">    version: 1.0.0</div>
+          </div>
+          <!-- Line 11 -->
+          <div class="diff-line">
+            <div class="line-number">11</div>
+            <div class="line-content">    repository: https://charts.bitnami.com/bitnami</div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  
+  <script>
+    (function() {
+      const vscode = acquireVsCodeApi();
+      const diffId = "${diffId}";
+      
+      // Setup button event listeners
+      document.getElementById('accept-btn').addEventListener('click', () => {
+        vscode.postMessage({
+          command: 'acceptChanges',
+          diffId: diffId,
+          filePath: 'Chart.yaml'
+        });
+      });
+      
+      document.getElementById('reject-btn').addEventListener('click', () => {
+        vscode.postMessage({
+          command: 'rejectChanges',
+          diffId: diffId,
+          filePath: 'Chart.yaml'
+        });
+      });
+      
+      // Request content from the extension
+      vscode.postMessage({
+        command: 'getDiffContent',
+        diffId: diffId
+      });
+      
+      // Listen for messages from the extension
+      window.addEventListener('message', event => {
+        const message = event.data;
+        
+        if (message.command === 'diffContent') {
+          // Update workspace info if needed
+          const content = message.content;
+          const workspaceInfo = document.querySelector('.workspace-info');
+          if (workspaceInfo && content.workspaceId && content.workspaceName) {
+            workspaceInfo.textContent = content.workspaceName + " — " + content.workspaceId;
+          }
+        }
+      });
+    })();
+  </script>
+</body>
+</html>`;
+} 

--- a/chartsmith-extension/src/modules/customDiff/index.ts
+++ b/chartsmith-extension/src/modules/customDiff/index.ts
@@ -1,0 +1,404 @@
+/**
+ * Main entry point for the custom diff functionality.
+ * This module creates a webview for navigating diffs from a remote Chartsmith workspace.
+ */
+
+import * as vscode from 'vscode';
+import * as path from 'path';
+import * as fs from 'fs';
+import { getDiffWebviewContent } from './diffWebview';
+
+// Track active diff webviews
+const activeDiffPanels = new Map<string, vscode.WebviewPanel>();
+
+// Keep track of file content for diff views
+export interface DiffContent {
+  filePath: string;
+  originalContent: string;
+  modifiedContent: string;
+  workspaceId: string;
+  workspaceName: string;
+  title?: string;
+  allFiles?: DiffFile[];
+  currentFileIndex?: number;
+}
+
+export interface DiffFile {
+  id: string;
+  path: string;
+  name: string;
+  status: 'added' | 'modified' | 'removed';
+  changes: number;
+}
+
+const diffContentRegistry = new Map<string, DiffContent>();
+
+/**
+ * Shows a diff between current content and new content using the custom diff viewer
+ * @param filePath The path to the file being diffed
+ * @param newContent The new content to compare
+ * @param workspaceId The ID of the workspace this diff belongs to
+ * @param workspaceName The name of the workspace this diff belongs to
+ * @param allFiles Optional array of all files that have diffs
+ * @param currentFileIndex Optional index of the current file in the allFiles array
+ * @param title Optional title for the diff view
+ * @returns Promise that resolves when the diff is shown
+ */
+export async function showCustomFileDiff(
+  filePath: string,
+  newContent: string,
+  workspaceId: string,
+  workspaceName: string,
+  allFiles?: DiffFile[],
+  currentFileIndex?: number,
+  title?: string
+): Promise<void> {
+  try {
+    console.log(`[customDiff] Showing diff for ${filePath} in workspace ${workspaceName}`);
+
+    // Read current content or use empty string if file doesn't exist
+    let currentContent = '';
+    try {
+      if (fs.existsSync(filePath)) {
+        currentContent = await fs.promises.readFile(filePath, 'utf8');
+      }
+    } catch (error) {
+      console.error(`Error reading file: ${error}`);
+      // Continue with empty content
+    }
+
+    // Generate a unique ID for this diff session
+    const diffId = `diff-${Date.now()}-${Math.random().toString(36).substring(2, 7)}`;
+    const fileName = path.basename(filePath);
+
+    // Create or show webview panel
+    const panel = vscode.window.createWebviewPanel(
+      'chartsmithDiff',  // Type
+      `${fileName} - ${workspaceName}`, // Title with workspace name
+      vscode.ViewColumn.Active, // Editor column
+      {
+        enableScripts: true,
+        retainContextWhenHidden: true,
+        localResourceRoots: [
+          vscode.Uri.joinPath(
+            vscode.Uri.file(path.dirname(filePath)),
+            '..',
+            '..',
+            'node_modules'
+          )
+        ]
+      }
+    );
+
+    // Store the content for retrieval by the webview
+    diffContentRegistry.set(diffId, {
+      filePath,
+      originalContent: currentContent,
+      modifiedContent: newContent,
+      workspaceId,
+      workspaceName,
+      title: title || `Changes to ${fileName}`,
+      allFiles,
+      currentFileIndex
+    });
+
+    // Set webview content
+    panel.webview.html = getDiffWebviewContent(panel.webview, diffId);
+
+    // Handle messages from the webview
+    panel.webview.onDidReceiveMessage(
+      message => {
+        switch (message.command) {
+          case 'getDiffContent':
+            const content = diffContentRegistry.get(message.diffId);
+            if (content) {
+              panel.webview.postMessage({
+                command: 'diffContent',
+                content
+              });
+            }
+            break;
+          case 'acceptChanges':
+            handleAcceptChanges(message.diffId, message.filePath);
+            break;
+          case 'rejectChanges':
+            handleRejectChanges(message.diffId, message.filePath);
+            break;
+          case 'acceptAllChanges':
+            handleAcceptAllChanges(message.diffId);
+            break;
+          case 'rejectAllChanges':
+            handleRejectAllChanges(message.diffId);
+            break;
+          case 'navigateToFile':
+            navigateToFile(message.diffId, message.fileIndex);
+            break;
+        }
+      },
+      undefined,
+      []
+    );
+
+    // Store the panel reference
+    activeDiffPanels.set(diffId, panel);
+
+    // Clean up when the panel is closed
+    panel.onDidDispose(() => {
+      activeDiffPanels.delete(diffId);
+      diffContentRegistry.delete(diffId);
+    });
+
+    // Set keyboard focus to the webview
+    panel.reveal(vscode.ViewColumn.Active);
+
+  } catch (error) {
+    console.error('Error creating custom diff view:', error);
+    vscode.window.showErrorMessage(`Failed to show diff: ${error}`);
+  }
+}
+
+/**
+ * Handles accepting changes for a specific file
+ * @param diffId The ID of the diff session
+ * @param filePath The path of the file to accept changes for
+ */
+async function handleAcceptChanges(diffId: string, filePath?: string): Promise<void> {
+  const content = diffContentRegistry.get(diffId);
+  if (!content) {
+    return;
+  }
+
+  const fileToAccept = filePath || content.filePath;
+
+  try {
+    // Write the modified content to the file
+    await fs.promises.writeFile(fileToAccept, content.modifiedContent, 'utf8');
+    
+    // Show success message
+    vscode.window.showInformationMessage(`Changes accepted for ${path.basename(fileToAccept)}`);
+    
+    // If we have more files to navigate to, switch to the next one
+    if (content.allFiles && content.allFiles.length > 1 && content.currentFileIndex !== undefined) {
+      const nextIndex = (content.currentFileIndex + 1) % content.allFiles.length;
+      navigateToFile(diffId, nextIndex);
+    } else {
+      // Close the panel if this is the only file
+      const panel = activeDiffPanels.get(diffId);
+      if (panel) {
+        panel.dispose();
+      }
+      
+      // Clean up
+      activeDiffPanels.delete(diffId);
+      diffContentRegistry.delete(diffId);
+    }
+  } catch (error) {
+    console.error('Error accepting changes:', error);
+    vscode.window.showErrorMessage(`Failed to accept changes: ${error}`);
+  }
+}
+
+/**
+ * Handles rejecting changes for a specific file
+ * @param diffId The ID of the diff session
+ * @param filePath The path of the file to reject changes for
+ */
+async function handleRejectChanges(diffId: string, filePath?: string): Promise<void> {
+  const content = diffContentRegistry.get(diffId);
+  if (!content) {
+    return;
+  }
+
+  const fileToReject = filePath || content.filePath;
+
+  try {
+    // Show rejection message
+    vscode.window.showInformationMessage(`Changes rejected for ${path.basename(fileToReject)}`);
+    
+    // If we have more files to navigate to, switch to the next one
+    if (content.allFiles && content.allFiles.length > 1 && content.currentFileIndex !== undefined) {
+      const nextIndex = (content.currentFileIndex + 1) % content.allFiles.length;
+      navigateToFile(diffId, nextIndex);
+    } else {
+      // Close the panel if this is the only file
+      const panel = activeDiffPanels.get(diffId);
+      if (panel) {
+        panel.dispose();
+      }
+      
+      // Clean up
+      activeDiffPanels.delete(diffId);
+      diffContentRegistry.delete(diffId);
+    }
+  } catch (error) {
+    console.error('Error rejecting changes:', error);
+    vscode.window.showErrorMessage(`Failed to reject changes: ${error}`);
+  }
+}
+
+/**
+ * Handles accepting all changes in the diff session
+ * @param diffId The ID of the diff session
+ */
+async function handleAcceptAllChanges(diffId: string): Promise<void> {
+  const content = diffContentRegistry.get(diffId);
+  if (!content || !content.allFiles) {
+    return;
+  }
+
+  try {
+    // Here in a real implementation, you would write the modified content for all files
+    // For this mockup, we'll just show a message
+    vscode.window.showInformationMessage(`All changes accepted in workspace ${content.workspaceName}`);
+    
+    // Close the panel
+    const panel = activeDiffPanels.get(diffId);
+    if (panel) {
+      panel.dispose();
+    }
+    
+    // Clean up
+    activeDiffPanels.delete(diffId);
+    diffContentRegistry.delete(diffId);
+  } catch (error) {
+    console.error('Error accepting all changes:', error);
+    vscode.window.showErrorMessage(`Failed to accept all changes: ${error}`);
+  }
+}
+
+/**
+ * Handles rejecting all changes in the diff session
+ * @param diffId The ID of the diff session
+ */
+async function handleRejectAllChanges(diffId: string): Promise<void> {
+  const content = diffContentRegistry.get(diffId);
+  if (!content || !content.allFiles) {
+    return;
+  }
+
+  try {
+    // In a real implementation, you would reject changes for all files
+    // For this mockup, we'll just show a message
+    vscode.window.showInformationMessage(`All changes rejected in workspace ${content.workspaceName}`);
+    
+    // Close the panel
+    const panel = activeDiffPanels.get(diffId);
+    if (panel) {
+      panel.dispose();
+    }
+    
+    // Clean up
+    activeDiffPanels.delete(diffId);
+    diffContentRegistry.delete(diffId);
+  } catch (error) {
+    console.error('Error rejecting all changes:', error);
+    vscode.window.showErrorMessage(`Failed to reject all changes: ${error}`);
+  }
+}
+
+/**
+ * Navigates to a specific file in the diff session
+ * @param diffId The ID of the diff session
+ * @param fileIndex The index of the file to navigate to
+ */
+async function navigateToFile(diffId: string, fileIndex: number): Promise<void> {
+  const content = diffContentRegistry.get(diffId);
+  if (!content || !content.allFiles || fileIndex >= content.allFiles.length) {
+    return;
+  }
+
+  try {
+    const targetFile = content.allFiles[fileIndex];
+    
+    // In a real implementation, you would load the content of the target file
+    // For this mockup, we'll just update the current file index and notify the webview
+    const updatedContent: DiffContent = {
+      ...content,
+      currentFileIndex: fileIndex,
+      filePath: targetFile.path,
+      title: `Changes to ${targetFile.name}`
+    };
+    
+    diffContentRegistry.set(diffId, updatedContent);
+    
+    // Update the panel title
+    const panel = activeDiffPanels.get(diffId);
+    if (panel) {
+      panel.title = `${targetFile.name} - ${content.workspaceName}`;
+      
+      // Notify the webview of the navigation
+      panel.webview.postMessage({
+        command: 'diffContent',
+        content: updatedContent
+      });
+    }
+  } catch (error) {
+    console.error('Error navigating to file:', error);
+    vscode.window.showErrorMessage(`Failed to navigate to file: ${error}`);
+  }
+}
+
+/**
+ * Registers commands for the custom diff functionality
+ * @param context Extension context
+ */
+export function registerCustomDiffCommands(context: vscode.ExtensionContext): void {
+  context.subscriptions.push(
+    vscode.commands.registerCommand('chartsmith.showCustomFileDiff', async () => {
+      // Create hard-coded sample Chart.yaml with version change
+      const originalContent = 
+`apiVersion: v2
+name: my-helm-chart
+description: A Helm chart for Kubernetes
+type: application
+version: 0.6.5
+appVersion: "1.16.0"
+dependencies:
+  - name: common
+    version: 1.0.0
+    repository: https://charts.bitnami.com/bitnami`;
+
+      const modifiedContent = 
+`apiVersion: v2
+name: my-helm-chart
+description: A Helm chart for Kubernetes
+type: application
+version: 0.7.0
+appVersion: "1.16.0"
+dependencies:
+  - name: common
+    version: 1.0.0
+    repository: https://charts.bitnami.com/bitnami`;
+      
+      // Use a sample workspace ID
+      const workspaceId = "ws-23fdb97";
+      const workspaceName = "My Chartsmith Workspace";
+      
+      // Sample path - using a hypothetical chart path
+      const filePath = "/Chart.yaml";
+      
+      // Show the diff
+      await showCustomFileDiff(
+        filePath,
+        modifiedContent,
+        workspaceId,
+        workspaceName,
+        [{
+          id: 'file-1',
+          path: '/Chart.yaml',
+          name: 'Chart.yaml',
+          status: 'modified',
+          changes: 1
+        }],
+        0,
+        `Changes to Chart.yaml`
+      );
+    })
+  );
+}
+
+// Make sure to export the module
+export default {
+  showCustomFileDiff,
+  registerCustomDiffCommands
+}; 

--- a/chartsmith-extension/src/modules/customDiff/module.ts
+++ b/chartsmith-extension/src/modules/customDiff/module.ts
@@ -1,0 +1,22 @@
+/**
+ * Custom diff module entry point.
+ * Exports the functionality for showing diffs from remote Chartsmith workspaces.
+ */
+
+import * as vscode from 'vscode';
+import customDiffModule from './index';
+
+/**
+ * Initializes the custom diff module
+ * @param context VS Code extension context
+ */
+export function initializeCustomDiffModule(context: vscode.ExtensionContext): void {
+  // Register commands
+  customDiffModule.registerCustomDiffCommands(context);
+  
+  console.log('Custom diff module initialized');
+}
+
+export {
+  customDiffModule
+}; 

--- a/design/vscode-extension-diffs/README.md
+++ b/design/vscode-extension-diffs/README.md
@@ -1,0 +1,86 @@
+# Native Diff Implementation for Chartsmith Extension
+
+This document explores an approach for replacing VS Code's built-in diff functionality with Chartsmith's own native diff experience from the main application.
+
+## Current Implementation
+
+Currently, the Chartsmith extension uses VS Code's native diff functionality:
+
+- Creates virtual documents with the current file content and proposed changes
+- Uses VS Code's `vscode.diff` command to display these documents side-by-side
+- Implements custom buttons for accepting/rejecting changes
+- Handles file content storage and synchronization
+
+## Strategic Goals and Unified Experience
+
+A key strategic goal for this implementation is to **unify the Chartsmith experience across platforms** - whether using the browser application or the VS Code extension. Key aspects of this strategy include:
+
+### 1. Consistent User Experience
+
+- Users would encounter the same UI patterns and workflows regardless of platform
+- Visual consistency in diff presentation, controls, and actions reduces cognitive load
+- Familiar navigation and interaction patterns help when switching contexts
+
+### 2. Upstream-First Architecture
+
+- The implementation follows an "upstream-first" approach, where the remote workspace serves as the primary source of functionality and data
+- The VS Code extension adapts and integrates with the remote workspace rather than implementing standalone features
+- Instead of duplicating diff handling logic in the VS Code extension, the implementation delegates to the remote workspace for processing diffs, applying changes, and managing state. This ensures that complex operations like conflict resolution and version tracking remain consistent regardless of where a user accesses Chartsmith.
+
+### 3. Streamlined Synchronized Workspace Model
+
+The architecture creates an efficient, secure flow for synchronizing workspaces between local and remote environments:
+
+- **User-Initiated Changes**: All modifications begin with explicit user actions in the VS Code extension (accepting/rejecting diffs)
+- **Remote Workspace Processing**: When a user accepts a change locally, the request is sent to the remote workspace for processing and application
+- **Confirmation Flow**: After successful application to the remote workspace, the extension receives confirmation and only then applies the same changes locally
+- **Transaction Integrity**: This sequence ensures both environments remain in sync, with changes only applied locally after confirmed remote application
+
+This model eliminates redundancy while maintaining security, ensuring that local changes are only finalized after successful remote processing, creating a consistent state across platforms without requiring users to approve the same change multiple times.
+
+## The Case for a Custom Diff Implementation
+
+### Webview-Based Architecture with Remote Workspace as Source of Truth
+
+The Chartsmith extension already uses a webview-based architecture to communicate with remote workspaces. Extending this pattern to diffs while using the remote workspace as the source of truth offers several key advantages:
+
+1. **Centralized State and Communication**:
+   - The remote workspace acts as the single source of truth for all diff states
+   - The webview facilitates bidirectional communication between local and remote environments
+   - Changes propagate efficiently in both directions through established communication channels
+   
+2. **Unified User Experience**:
+   - Consistent visual design and interaction patterns across all platforms
+   - Users encounter the same workflows regardless of access method (browser or VS Code)
+   - Brand identity and design language remain consistent across all touchpoints
+
+3. **Simplified Development and Maintenance**:
+   - Reduces duplication of code between the web app and VS Code extension
+   - Leverages existing components and patterns from the main application
+   - Centralizes complex logic like conflict resolution and version tracking
+   
+4. **Improved Debugging and Quality Assurance**:
+   - State changes are more transparent and traceable through server-side logging
+   - Centralized management simplifies testing and validation
+   - Reduces context-switching between client and server debugging
+
+## Challenges to Consider
+
+While the webview-based approach offers numerous advantages, there are challenges to consider:
+
+### 1. Performance Considerations
+
+- Webviews add overhead compared to native VS Code components
+- Large diffs or many simultaneous diffs may impact performance
+- Network latency can affect the user experience when communicating with remote workspaces
+
+### 2. Integration Limitations
+
+- Some VS Code features are difficult to replicate in a webview
+- Extension capabilities are more limited than native VS Code functionality
+- User expectations about standard editor behavior
+
+### 3. Development Complexity
+
+- Maintaining the webview implementation may add complexity of its own
+- Ensuring proper synchronization requires careful design


### PR DESCRIPTION
This PR explores an approach for replacing VS Code's built-in diff functionality with Chartsmith's own native diff experience from the main application. 

Very simple mock up is included which can be accessed through the command palette(`Chartsmith: Show Native File Diff`)

See [design/vscode-extension-diffs/README.md](https://github.com/replicatedhq/chartsmith/blob/diamonwiggins/improve-diff-ux/design/vscode-extension-diffs/README.md) for more details

<img width="1512" alt="Screenshot 2025-05-02 at 11 34 29 PM" src="https://github.com/user-attachments/assets/fb172942-8027-4891-a237-cf8d3b066e1e" />
