### PR TITLE
feat: Securebuild integration

### DIFF
--- a/chartsmith-app/app/api/workspace/[workspaceId]/message/route.ts
+++ b/chartsmith-app/app/api/workspace/[workspaceId]/message/route.ts
@@ -1,5 +1,6 @@
 import { userIdFromExtensionToken } from "@/lib/auth/extension-token";
 import { createChatMessage, CreateChatMessageParams } from "@/lib/workspace/workspace";
+import { getUserSettings } from "@/lib/auth/user";
 import { NextRequest, NextResponse } from "next/server";
 
 
@@ -28,8 +29,12 @@ export async function POST(req: NextRequest) {
     const body = await req.json();
     const { prompt } = body;
 
+    // Get user settings to access SecureBuild preference
+    const userSettings = await getUserSettings(userId);
+
     const createChatMessageParams: CreateChatMessageParams = {
       prompt,
+      useSecureBuildImages: userSettings.useSecureBuildImages,
     };
 
     const chatMessage = await createChatMessage(userId, workspaceId, createChatMessageParams);

--- a/chartsmith-app/app/hooks/useSession.ts
+++ b/chartsmith-app/app/hooks/useSession.ts
@@ -83,8 +83,27 @@ export const useSession = (redirectIfNotLoggedIn: boolean = false) => {
     validate(token);
   }, [router, redirectIfNotLoggedIn]);
 
+  const refreshSession = useCallback(async () => {
+    const token = document.cookie
+      .split("; ")
+      .find((cookie) => cookie.startsWith("session="))
+      ?.split("=")[1];
+
+    if (!token) {
+      return;
+    }
+
+    try {
+      const sess = await validateSession(token);
+      setSession(sess);
+    } catch (error) {
+      logger.error("Session refresh failed:", error);
+    }
+  }, []);
+
   return {
     isLoading,
     session,
+    refreshSession,
   };
 };

--- a/chartsmith-app/lib/auth/session.ts
+++ b/chartsmith-app/lib/auth/session.ts
@@ -92,7 +92,6 @@ export async function sessionToken(session: Session): Promise<string> {
       name: session.user.name,
       email: session.user.email,
       picture: session.user.imageUrl,
-      userSettings: session.user.settings,
       isWaitlisted: session.user.isWaitlisted,
       isAdmin: session.user.isAdmin || false
     };
@@ -193,6 +192,9 @@ export async function findSession(token: string): Promise<Session | undefined> {
                   settings: {
                     automaticallyAcceptPatches: false,
                     evalBeforeAccept: false,
+                    theme: 'auto',
+                    tabSize: '2 spaces',
+                    showMinimap: false,
                   },
                   isAdmin: false
                 },
@@ -237,6 +239,9 @@ export async function findSession(token: string): Promise<Session | undefined> {
             settings: {
               automaticallyAcceptPatches: false,
               evalBeforeAccept: false,
+              theme: 'auto',
+              tabSize: '2 spaces',
+              showMinimap: false,
             },
             isAdmin: false
           };

--- a/chartsmith-app/lib/auth/session.ts
+++ b/chartsmith-app/lib/auth/session.ts
@@ -195,6 +195,7 @@ export async function findSession(token: string): Promise<Session | undefined> {
                     theme: 'auto',
                     tabSize: '2 spaces',
                     showMinimap: false,
+                    useSecureBuildImages: false,
                   },
                   isAdmin: false
                 },
@@ -242,6 +243,7 @@ export async function findSession(token: string): Promise<Session | undefined> {
               theme: 'auto',
               tabSize: '2 spaces',
               showMinimap: false,
+              useSecureBuildImages: false,
             },
             isAdmin: false
           };

--- a/chartsmith-app/lib/auth/user.ts
+++ b/chartsmith-app/lib/auth/user.ts
@@ -12,6 +12,7 @@ const defaultUserSettings: UserSetting = {
   theme: 'auto',
   tabSize: '2 spaces',
   showMinimap: false,
+  useSecureBuildImages: false,
 };
 
 /**
@@ -270,6 +271,9 @@ export async function getUserSettings(id: string): Promise<UserSetting> {
         case "show_minimap":
           userSettings.showMinimap = row.value === "true";
           break;
+        case "use_secure_build_images":
+          userSettings.useSecureBuildImages = row.value === "true";
+          break;
       }
     }
 
@@ -396,6 +400,7 @@ export async function listWaitlistUsers(): Promise<User[]> {
           theme: 'auto',
           tabSize: '2 spaces',
           showMinimap: false,
+          useSecureBuildImages: false,
         },
         isAdmin: false,
       });

--- a/chartsmith-app/lib/types/user.ts
+++ b/chartsmith-app/lib/types/user.ts
@@ -32,4 +32,5 @@ export interface UserSetting {
   theme: string;
   tabSize: string;
   showMinimap: boolean;
+  useSecureBuildImages: boolean;
 }

--- a/chartsmith-app/lib/types/user.ts
+++ b/chartsmith-app/lib/types/user.ts
@@ -29,4 +29,7 @@ export interface User {
 export interface UserSetting {
   automaticallyAcceptPatches: boolean;
   evalBeforeAccept: boolean;
+  theme: string;
+  tabSize: string;
+  showMinimap: boolean;
 }

--- a/chartsmith-app/lib/workspace/actions/create-workspace-from-prompt.ts
+++ b/chartsmith-app/lib/workspace/actions/create-workspace-from-prompt.ts
@@ -11,6 +11,7 @@ export async function createWorkspaceFromPromptAction(session: Session, prompt: 
   const createChartMessageParams: CreateChatMessageParams = {
     prompt: prompt,
     messageFromPersona: ChatMessageFromPersona.AUTO,
+    useSecureBuildImages: session.user.settings.useSecureBuildImages,
   }
   const w = await createWorkspace("prompt", session.user.id, createChartMessageParams);
 

--- a/chartsmith-app/lib/workspace/workspace.ts
+++ b/chartsmith-app/lib/workspace/workspace.ts
@@ -159,6 +159,7 @@ export interface CreateChatMessageParams {
   additionalFiles?: WorkspaceFile[];
   responseRollbackToRevisionNumber?: number;
   messageFromPersona?: ChatMessageFromPersona;
+  useSecureBuildImages?: boolean;
 }
 
 export async function createChatMessage(userId: string, workspaceId: string, params: CreateChatMessageParams): Promise<ChatMessage> {
@@ -237,6 +238,7 @@ export async function createChatMessage(userId: string, workspaceId: string, par
       await enqueueWork("new_plan", {
         planId: plan.id,
         additionalFiles: params.additionalFiles,
+        useSecureBuildImages: params.useSecureBuildImages,
       });
     } else if (params.knownIntent === ChatMessageIntent.NON_PLAN) {
       await enqueueWork("conversational", {
@@ -1058,7 +1060,10 @@ export async function createRevision(plan: Plan, userID: string): Promise<number
     // Commit transaction
     await db.query('COMMIT');
 
-    await enqueueWork("execute_plan", { planId: plan.id });
+    await enqueueWork("execute_plan", { 
+      planId: plan.id,
+      options: { useSecureBuildImages: false }  // Default options for frontend-created revisions
+    });
 
     return newRevisionNumber;
 

--- a/chartsmith-app/lib/workspace/workspace.ts
+++ b/chartsmith-app/lib/workspace/workspace.ts
@@ -239,7 +239,10 @@ export async function createChatMessage(userId: string, workspaceId: string, par
         additionalFiles: params.additionalFiles,
       });
     } else if (params.knownIntent === ChatMessageIntent.NON_PLAN) {
-      await client.query(`SELECT pg_notify('new_nonplan_chat_message', $1)`, [chatMessageId]);
+      await enqueueWork("conversational", {
+        chatMessageId,
+        workspaceId,
+      });
     } else if (params.knownIntent === ChatMessageIntent.RENDER) {
       await renderWorkspace(workspaceId, chatMessageId);
     } else if (params.knownIntent === ChatMessageIntent.CONVERT_K8S_TO_HELM) {

--- a/chartsmith-app/tests/upload-chart.spec.ts
+++ b/chartsmith-app/tests/upload-chart.spec.ts
@@ -98,7 +98,7 @@ test('upload helm chart', async ({ page }) => {
     await page.screenshot({ path: './test-results/upload-proceed-button-verification.png' });
 
     // Test should fail if button is not visible in viewport
-    expect(isInViewport).toBe(true, 'Proceed button is not visible in the viewport without scrolling');
+    expect(isInViewport).toBe(true);
 
     // click on the Proceed button
     await proceedButton.click();

--- a/pkg/backend/options.go
+++ b/pkg/backend/options.go
@@ -1,0 +1,6 @@
+package backend
+
+// Options represents backend processing options that can be passed to LLM functions
+type Options struct {
+	UseSecureBuildImages bool `json:"useSecureBuildImages,omitempty"`
+}

--- a/pkg/debugcli/console.go
+++ b/pkg/debugcli/console.go
@@ -16,6 +16,7 @@ import (
 	"github.com/fatih/color"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/pkg/errors"
+	"github.com/replicatedhq/chartsmith/pkg/backend"
 	"github.com/replicatedhq/chartsmith/pkg/llm"
 	llmtypes "github.com/replicatedhq/chartsmith/pkg/llm/types"
 	"github.com/replicatedhq/chartsmith/pkg/logger"
@@ -1363,7 +1364,7 @@ func (c *DebugConsole) executePlan(args []string) error {
 	doneCh := make(chan error)
 
 	go func() {
-		_, err := llm.ExecuteAction(c.ctx, actionPlanWithPath, plan, currentContent, interimContentCh)
+		_, err := llm.ExecuteAction(c.ctx, actionPlanWithPath, plan, currentContent, interimContentCh, backend.Options{})
 		if err != nil {
 			fmt.Println(dimText(fmt.Sprintf("Error: %v", err)))
 		}

--- a/pkg/listener/execute-plan.go
+++ b/pkg/listener/execute-plan.go
@@ -12,13 +12,15 @@ import (
 	"github.com/replicatedhq/chartsmith/pkg/persistence"
 	"github.com/replicatedhq/chartsmith/pkg/realtime"
 	realtimetypes "github.com/replicatedhq/chartsmith/pkg/realtime/types"
+	"github.com/replicatedhq/chartsmith/pkg/backend"
 	"github.com/replicatedhq/chartsmith/pkg/workspace"
 	workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
 	"go.uber.org/zap"
 )
 
 type executePlanPayload struct {
-	PlanID string `json:"planId"`
+	PlanID  string       `json:"planId"`
+	Options backend.Options `json:"options,omitempty"`
 }
 
 func handleExecutePlanNotification(ctx context.Context, payload string) error {
@@ -164,6 +166,7 @@ func handleExecutePlanNotification(ctx context.Context, payload string) error {
 			// This is what starts the actual processing
 			if err := persistence.EnqueueWork(ctx, "apply_plan", map[string]interface{}{
 				"planId": plan.ID,
+				"options": p.Options,
 			}); err != nil {
 				return fmt.Errorf("failed to enqueue apply plan: %w", err)
 			}

--- a/pkg/llm/execute-action.go
+++ b/pkg/llm/execute-action.go
@@ -11,6 +11,7 @@ import (
 	llmtypes "github.com/replicatedhq/chartsmith/pkg/llm/types"
 	"github.com/replicatedhq/chartsmith/pkg/logger"
 	"github.com/replicatedhq/chartsmith/pkg/persistence"
+	"github.com/replicatedhq/chartsmith/pkg/backend"
 	workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
 	"github.com/tuvistavie/securerandom"
 	"go.uber.org/zap"
@@ -434,7 +435,7 @@ func findBestMatchRegion(content, oldStr string, minMatchLen int) (int, int) {
 	return -1, -1
 }
 
-func ExecuteAction(ctx context.Context, actionPlanWithPath llmtypes.ActionPlanWithPath, plan *workspacetypes.Plan, currentContent string, interimContentCh chan string) (string, error) {
+func ExecuteAction(ctx context.Context, actionPlanWithPath llmtypes.ActionPlanWithPath, plan *workspacetypes.Plan, currentContent string, interimContentCh chan string, options backend.Options) (string, error) {
 	updatedContent := currentContent
 	lastActivity := time.Now()
 
@@ -481,7 +482,7 @@ func ExecuteAction(ctx context.Context, actionPlanWithPath llmtypes.ActionPlanWi
 	}
 
 	messages := []anthropic.MessageParam{
-		anthropic.NewAssistantMessage(anthropic.NewTextBlock(executePlanSystemPrompt)),
+		anthropic.NewAssistantMessage(anthropic.NewTextBlock(GetExecutePlanSystemPrompt(options))),
 		anthropic.NewUserMessage(anthropic.NewTextBlock(detailedPlanInstructions)),
 	}
 

--- a/pkg/llm/execute-action.go
+++ b/pkg/llm/execute-action.go
@@ -239,23 +239,23 @@ func PerformStringReplacement(content, oldStr, newStr string) (string, bool, err
 	// Add logging to track performance
 	startTime := time.Now()
 	defer func() {
-		logger.Debug("String replacement operation completed", 
+		logger.Debug("String replacement operation completed",
 			zap.Duration("time_taken", time.Since(startTime)))
 	}()
-	
+
 	// Log content sizes for diagnostics
-	logger.Debug("Starting string replacement", 
-		zap.Int("content_size", len(content)), 
+	logger.Debug("Starting string replacement",
+		zap.Int("content_size", len(content)),
 		zap.Int("old_string_size", len(oldStr)),
 		zap.Int("new_string_size", len(newStr)))
-	
+
 	// First try exact match
 	if strings.Contains(content, oldStr) {
 		logger.Debug("Found exact match, performing replacement")
 		updatedContent := strings.ReplaceAll(content, oldStr, newStr)
 		return updatedContent, true, nil
 	}
-	
+
 	logger.Debug("No exact match found, attempting fuzzy matching")
 
 	// Create a context with timeout for fuzzy matching
@@ -272,14 +272,14 @@ func PerformStringReplacement(content, oldStr, newStr string) (string, bool, err
 	go func() {
 		logger.Debug("Starting fuzzy match search")
 		fuzzyStartTime := time.Now()
-		
+
 		start, end := findBestMatchRegion(content, oldStr, minFuzzyMatchLen)
-		
-		logger.Debug("Fuzzy match search completed", 
+
+		logger.Debug("Fuzzy match search completed",
 			zap.Duration("time_taken", time.Since(fuzzyStartTime)),
 			zap.Int("start_pos", start),
 			zap.Int("end_pos", end))
-			
+
 		if start == -1 || end == -1 {
 			resultCh <- struct {
 				start, end int
@@ -301,15 +301,15 @@ func PerformStringReplacement(content, oldStr, newStr string) (string, bool, err
 			return content, false, result.err
 		}
 		// Replace the matched region with newStr
-		logger.Debug("Found fuzzy match, performing replacement", 
-			zap.Int("match_start", result.start), 
+		logger.Debug("Found fuzzy match, performing replacement",
+			zap.Int("match_start", result.start),
 			zap.Int("match_end", result.end),
 			zap.Int("match_length", result.end - result.start))
-			
+
 		updatedContent := content[:result.start] + newStr + content[result.end:]
 		return updatedContent, false, nil
 	case <-ctx.Done():
-		logger.Warn("Fuzzy matching timed out", 
+		logger.Warn("Fuzzy matching timed out",
 			zap.Duration("timeout", fuzzyMatchTimeout),
 			zap.Duration("time_elapsed", time.Since(startTime)))
 		return content, false, fmt.Errorf("fuzzy matching timed out after %v", fuzzyMatchTimeout)
@@ -319,8 +319,8 @@ func PerformStringReplacement(content, oldStr, newStr string) (string, bool, err
 func findBestMatchRegion(content, oldStr string, minMatchLen int) (int, int) {
 	// Early return if strings are too small
 	if len(oldStr) < minMatchLen {
-		logger.Debug("String too small for fuzzy matching", 
-			zap.Int("length", len(oldStr)), 
+		logger.Debug("String too small for fuzzy matching",
+			zap.Int("length", len(oldStr)),
 			zap.Int("min_length", minMatchLen))
 		return -1, -1
 	}
@@ -328,7 +328,7 @@ func findBestMatchRegion(content, oldStr string, minMatchLen int) (int, int) {
 	bestStart := -1
 	bestEnd := -1
 	bestLen := 0
-	
+
 	// Set a max number of chunks to process to prevent excessive computation
 	maxChunks := 100
 	chunksProcessed := 0
@@ -344,32 +344,32 @@ func findBestMatchRegion(content, oldStr string, minMatchLen int) (int, int) {
 
 		// Get the current chunk
 		chunk := oldStr[i:chunkEnd]
-		
+
 		// Skip empty or tiny chunks
 		if len(chunk) < 10 {
 			continue
 		}
-		
+
 		chunksProcessed++
-		
+
 		// Find all occurrences of this chunk in the content
 		start := 0
 		maxOccurrences := 100  // Limit number of occurrences to check
 		occurrencesChecked := 0
-		
-		logger.Debug("Processing chunk", 
-			zap.Int("chunk_index", i), 
+
+		logger.Debug("Processing chunk",
+			zap.Int("chunk_index", i),
 			zap.Int("chunk_size", len(chunk)),
 			zap.Int("chunks_processed", chunksProcessed))
-		
+
 		for occurrencesChecked < maxOccurrences {
 			idx := strings.Index(content[start:], chunk)
 			if idx == -1 {
 				break
 			}
-			
+
 			occurrencesChecked++
-			
+
 			// Adjust index to be relative to the start of content
 			idx += start
 
@@ -377,7 +377,7 @@ func findBestMatchRegion(content, oldStr string, minMatchLen int) (int, int) {
 			matchStart := idx
 			matchEnd := idx + len(chunk)
 			matchLen := len(chunk)
-			
+
 			// Store the original i value, we'll need it for backward extension
 			originalI := i
 
@@ -408,8 +408,8 @@ func findBestMatchRegion(content, oldStr string, minMatchLen int) (int, int) {
 				bestStart = matchStart
 				bestEnd = matchEnd
 				bestLen = matchLen
-				
-				logger.Debug("Found better match", 
+
+				logger.Debug("Found better match",
 					zap.Int("match_length", matchLen),
 					zap.Int("match_start", matchStart),
 					zap.Int("match_end", matchEnd))
@@ -421,13 +421,13 @@ func findBestMatchRegion(content, oldStr string, minMatchLen int) (int, int) {
 	}
 
 	if bestLen >= minMatchLen {
-		logger.Debug("Found best match", 
+		logger.Debug("Found best match",
 			zap.Int("best_length", bestLen),
 			zap.Int("best_start", bestStart),
 			zap.Int("best_end", bestEnd))
 		return bestStart, bestEnd
 	}
-	
+
 	logger.Debug("No match found with minimum length",
 		zap.Int("best_length", bestLen),
 		zap.Int("required_min_length", minMatchLen))

--- a/pkg/llm/execute-action_test.go
+++ b/pkg/llm/execute-action_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/replicatedhq/chartsmith/pkg/backend"
 	llmtypes "github.com/replicatedhq/chartsmith/pkg/llm/types"
 	"github.com/replicatedhq/chartsmith/pkg/param"
 	workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
@@ -1131,7 +1132,7 @@ unsupported:
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			patchStreamCh := make(chan string)
-			got, err := ExecuteAction(ctx, tt.actionPlanWithPath, tt.plan, tt.currentContent, patchStreamCh)
+			got, err := ExecuteAction(ctx, tt.actionPlanWithPath, tt.plan, tt.currentContent, patchStreamCh, backend.Options{})
 			if (err != nil) != tt.wantErr {
 				t.Errorf("ExecuteAction() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/llm/initial-plan.go
+++ b/pkg/llm/initial-plan.go
@@ -7,6 +7,7 @@ import (
 
 	anthropic "github.com/anthropics/anthropic-sdk-go"
 	"github.com/replicatedhq/chartsmith/pkg/logger"
+	"github.com/replicatedhq/chartsmith/pkg/backend"
 	"github.com/replicatedhq/chartsmith/pkg/workspace"
 	workspacetypes "github.com/replicatedhq/chartsmith/pkg/workspace/types"
 	"go.uber.org/zap"
@@ -16,6 +17,7 @@ type CreateInitialPlanOpts struct {
 	ChatMessages    []workspacetypes.Chat
 	PreviousPlans   []workspacetypes.Plan
 	AdditionalFiles []workspacetypes.File
+	Options         backend.Options
 }
 
 func CreateInitialPlan(ctx context.Context, streamCh chan string, doneCh chan error, opts CreateInitialPlanOpts) error {
@@ -31,7 +33,7 @@ func CreateInitialPlan(ctx context.Context, streamCh chan string, doneCh chan er
 	}
 
 	messages := []anthropic.MessageParam{
-		anthropic.NewAssistantMessage(anthropic.NewTextBlock(initialPlanSystemPrompt)),
+		anthropic.NewAssistantMessage(anthropic.NewTextBlock(GetInitialPlanSystemPrompt(opts.Options))),
 		anthropic.NewAssistantMessage(anthropic.NewTextBlock(initialPlanInstructions)),
 	}
 

--- a/pkg/llm/system.go
+++ b/pkg/llm/system.go
@@ -1,5 +1,10 @@
 package llm
 
+import (
+	"github.com/replicatedhq/chartsmith/pkg/backend"
+	"github.com/replicatedhq/chartsmith/pkg/logger"
+)
+
 const endUserSystemPrompt = `You are ChartSmith, an expert AI assistant and a highly skilled senior SRE specializing in using Helm charts to deploy applications to Kubernetes.
  Your primary responsibility is to configure and install and upgrade applications using Helm charts.
 
@@ -138,3 +143,34 @@ const convertFileSystemPrompt = commonSystemPrompt + `
   - When creating new values for the values.yaml, expect that this will be a complex chart and you should not have a very flat values.yaml schema
 </convert_file_instructions>
 `
+
+const secureBuildPromptAddition = `
+<secure_build_instructions>
+  - IMPORTANT: Use SecureBuild images from the cve0.io OCI repository when available.
+  - For all container images, prefer using images from cve0.io when they are available.
+  - When specifying image repositories, use cve0.io as the registry for images when possible.
+  - SecureBuild OCI repository URIs are formatted like cve0.io/postgres:17.6.
+  - This provides enhanced security through vulnerability-free container images.
+  - Make sure to note in the initial plan and chart values creation that SecureBuild (cve0.io) images are being used.
+</secure_build_instructions>
+`
+
+// GetInitialPlanSystemPrompt returns the initial plan system prompt with optional SecureBuild additions
+func GetInitialPlanSystemPrompt(options backend.Options) string {
+	if options.UseSecureBuildImages {
+		logger.Info("Adding SecureBuild instructions to initial plan system prompt")
+		return initialPlanSystemPrompt + secureBuildPromptAddition
+	}
+	logger.Info("Using standard initial plan system prompt (no SecureBuild)")
+	return initialPlanSystemPrompt
+}
+
+// GetExecutePlanSystemPrompt returns the execute plan system prompt with optional SecureBuild additions
+func GetExecutePlanSystemPrompt(options backend.Options) string {
+	if options.UseSecureBuildImages {
+		logger.Info("Adding SecureBuild instructions to execute plan system prompt")
+		return executePlanSystemPrompt + secureBuildPromptAddition
+	}
+	logger.Info("Using standard execute plan system prompt (no SecureBuild)")
+	return executePlanSystemPrompt
+}

--- a/pkg/workspace/revision.go
+++ b/pkg/workspace/revision.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/replicatedhq/chartsmith/pkg/logger"
 	"github.com/replicatedhq/chartsmith/pkg/persistence"
+	"github.com/replicatedhq/chartsmith/pkg/backend"
 	"github.com/replicatedhq/chartsmith/pkg/workspace/types"
 	"go.uber.org/zap"
 )
@@ -44,7 +45,7 @@ func GetRevision(ctx context.Context, workspaceID string, revisionNumber int) (*
 	return &revision, nil
 }
 
-func CreateRevision(ctx context.Context, workspaceID string, planID *string, userID string) (types.Revision, error) {
+func CreateRevision(ctx context.Context, workspaceID string, planID *string, userID string, options backend.Options) (types.Revision, error) {
 	logger.Info("Creating revision",
 		zap.String("workspace_id", workspaceID),
 		zap.String("user_id", userID))
@@ -141,6 +142,7 @@ func CreateRevision(ctx context.Context, workspaceID string, planID *string, use
 
 	if err := persistence.EnqueueWork(ctx, "execute_plan", map[string]interface{}{
 		"planId": planID,
+		"options": options,
 	}); err != nil {
 		logger.Warn("failed to enqueue execute_plan notification", zap.Error(err))
 		// but do not exit

--- a/pkg/workspace/user.go
+++ b/pkg/workspace/user.go
@@ -1,0 +1,27 @@
+package workspace
+
+import (
+	"context"
+
+	"github.com/replicatedhq/chartsmith/pkg/persistence"
+)
+
+// GetUserSecureBuildSetting retrieves the user's SecureBuild setting from the database
+func GetUserSecureBuildSetting(ctx context.Context, userID string) (bool, error) {
+	conn := persistence.MustGetPooledPostgresSession()
+	defer conn.Release()
+
+	var value string
+	err := conn.QueryRow(ctx, `
+		SELECT value
+		FROM chartsmith_user_setting
+		WHERE user_id = $1 AND key = 'use_secure_build_images'
+	`, userID).Scan(&value)
+
+	if err != nil {
+		// If no setting found, return false (default)
+		return false, nil
+	}
+
+	return value == "true", nil
+}


### PR DESCRIPTION
integration for https://securebuild.com/

this PR:
- adds an "Images Settings" section to user settings, which contains a checkbox for "Use SecureBuild images (cve0.io)"
- when enabled:
  - ChartSmith will prefer container images from the SecureBuild cve0.io registry
  - the execution plan will note the plan to use cve0.io, and the rendering will include cve0.io registry in values.yaml 
- when disabled (default):
  - the execution plan and rendering will not know anything about SecureBuild or the cve0 registry, just like before

includes the commit from:
- #113 

the current PR is in draft until #113 is merged. until then, review only the second commit: e55f5c1ea3f575f0449d81ae1f7bf124a7fe7be0