### PR TITLE
test: reproduce non-YAML Helm notes validation

### DIFF
--- a/chart/chartsmith/templates/NOTES.txt
+++ b/chart/chartsmith/templates/NOTES.txt
@@ -1,1 +1,4 @@
 ChartSmith is running.
+
+To open the ChartSmith workspace:
+  Visit: the URL configured for your ChartSmith installation


### PR DESCRIPTION
## What

- expands the Chartsmith Helm notes with useful workspace access guidance
- provides a realistic non-YAML Helm notes document for end-to-end release validation

## Why

Vandoor PR #10339 rendered every Helm template and attempted to decode every result as Kubernetes YAML. Helm renders templates/NOTES.txt, but notes are user-facing text rather than Kubernetes manifests. That caused valid releases to fail and was reverted in replicatedhq/vandoor#10346.

This notes document is valid Helm output but intentionally not valid standalone YAML. It gives us a Chartsmith canary for restoring the lifecycle validation safely.

## Validation

- helm lint chart/chartsmith accepts the notes change; the clean checkout reports the existing missing replicated dependency warning
- against a local Vendor API with replicatedhq/vandoor#10346 reversed, release creation fails with the expected reproduction:

  chartsmith-0.3.7.tgz renders invalid YAML in chartsmith/templates/NOTES.txt document 1: yaml: line 3: mapping values are not allowed in this context

- no release was created or promoted

## Merge order

Use this PR to validate the Vandoor fix and merge it only after the restored lifecycle validator accepts the Chartsmith release.
